### PR TITLE
V1.3.0

### DIFF
--- a/batch-tool/pom.xml
+++ b/batch-tool/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alibaba.polardbx</groupId>
     <artifactId>batch-tool</artifactId>
-    <version>1.2.2</version>
+    <version>1.3.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -109,6 +109,12 @@
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
             <version>${fastjson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <version>0.10</version>
         </dependency>
 
         <!-- Guava -->

--- a/batch-tool/src/main/java/cmd/CommandUtil.java
+++ b/batch-tool/src/main/java/cmd/CommandUtil.java
@@ -23,6 +23,7 @@ import datasource.DataSourceConfig;
 import datasource.DatasourceConstant;
 import model.ConsumerExecutionContext;
 import model.ProducerExecutionContext;
+import model.config.BenchmarkMode;
 import model.config.CompressMode;
 import model.config.ConfigConstant;
 import model.config.DdlMode;
@@ -57,6 +58,7 @@ import java.util.stream.Collectors;
 import static cmd.ConfigArgOption.ARG_DDL_PARALLELISM;
 import static cmd.ConfigArgOption.ARG_DDL_RETRY_COUNT;
 import static cmd.ConfigArgOption.ARG_SHORT_BATCH_SIZE;
+import static cmd.ConfigArgOption.ARG_SHORT_BENCHMARK;
 import static cmd.ConfigArgOption.ARG_SHORT_CHARSET;
 import static cmd.ConfigArgOption.ARG_SHORT_COLUMNS;
 import static cmd.ConfigArgOption.ARG_SHORT_COMPRESS;
@@ -91,6 +93,7 @@ import static cmd.ConfigArgOption.ARG_SHORT_PRODUCER;
 import static cmd.ConfigArgOption.ARG_SHORT_QUOTE_ENCLOSE_MODE;
 import static cmd.ConfigArgOption.ARG_SHORT_READ_BLOCK_SIZE;
 import static cmd.ConfigArgOption.ARG_SHORT_RING_BUFFER_SIZE;
+import static cmd.ConfigArgOption.ARG_SHORT_SCALE;
 import static cmd.ConfigArgOption.ARG_SHORT_SEP;
 import static cmd.ConfigArgOption.ARG_SHORT_TABLE;
 import static cmd.ConfigArgOption.ARG_SHORT_TPS_LIMIT;
@@ -316,7 +319,7 @@ public class CommandUtil {
     }
 
     private static BaseOperateCommand parseImportCommand(ConfigResult result) {
-        requireOnlyOneArg(result, ARG_SHORT_FROM_FILE, ARG_SHORT_DIRECTORY);
+        requireOnlyOneArg(result, ARG_SHORT_FROM_FILE, ARG_SHORT_DIRECTORY, ARG_SHORT_BENCHMARK);
 
         ProducerExecutionContext producerExecutionContext = new ProducerExecutionContext();
         ConsumerExecutionContext consumerExecutionContext = new ConsumerExecutionContext();
@@ -547,6 +550,8 @@ public class CommandUtil {
         producerExecutionContext.setHistoryFileAndParse(getHistoryFile(result));
         producerExecutionContext.setQuoteEncloseMode(getQuoteEncloseMode(result));
         producerExecutionContext.setTrimRight(getTrimRight(result));
+        producerExecutionContext.setBenchmarkMode(getBenchmarkMode(result));
+        producerExecutionContext.setScale(getScale(result));
 
         producerExecutionContext.validate();
     }
@@ -629,6 +634,22 @@ public class CommandUtil {
         return !result.getBooleanFlag(ARG_TRIM_RIGHT);
     }
 
+    private static BenchmarkMode getBenchmarkMode(ConfigResult result) {
+        if (result.hasOption(ARG_SHORT_BENCHMARK)) {
+            return BenchmarkMode.parseMode(result.getOptionValue(ARG_SHORT_BENCHMARK));
+        } else {
+            return BenchmarkMode.NONE;
+        }
+    }
+
+    private static int getScale(ConfigResult result) {
+        if (result.hasOption(ARG_SHORT_SCALE)) {
+            return Integer.parseInt(result.getOptionValue(ARG_SHORT_SCALE));
+        } else {
+            return 0;
+        }
+    }
+
     private static boolean getForceParallelism(ConfigResult result) {
         if (result.hasOption(ARG_SHORT_FORCE_CONSUMER)) {
             return Boolean.parseBoolean(result.getOptionValue(ARG_SHORT_FORCE_CONSUMER));
@@ -663,6 +684,9 @@ public class CommandUtil {
             String dirPathStr = result.getOptionValue(ARG_SHORT_DIRECTORY);
             List<String> filePaths = FileUtil.getFilesAbsPathInDir(dirPathStr);
             return FileLineRecord.fromFilePaths(filePaths);
+        }
+        if (result.hasOption(ARG_SHORT_BENCHMARK)) {
+            return null;
         }
         throw new IllegalStateException("cannot get file path list");
     }

--- a/batch-tool/src/main/java/cmd/ConfigArgOption.java
+++ b/batch-tool/src/main/java/cmd/ConfigArgOption.java
@@ -120,13 +120,18 @@ public class ConfigArgOption {
     public static final ConfigArgOption ARG_SHORT_FILE_FORMAT =
         of("format", "fileFormat", "File format (default NONE).", "NONE | TXT | CSV | XLS | XLSX");
     public static final ConfigArgOption ARG_SHORT_MAX_ERROR =
-        of("error", "maxError", "Max error count threshold, program exits when the limit is exceeded.", "max error count");
+        of("error", "maxError", "Max error count threshold, program exits when the limit is exceeded.",
+            "max error count");
     public static final ConfigArgOption ARG_SHORT_MASK =
         of("mask", "mask", "Masking sensitive columns while exporting data.", "Json format config");
     public static final ConfigArgOption ARG_DDL_RETRY_COUNT =
         of("ddlRetry", "ddlRetry", "Retry times when import ddl throws exception.", "retry times");
     public static final ConfigArgOption ARG_DDL_PARALLELISM =
         of("ddlParallelism", "ddlParallelism", "Parallelism of ddl statements.", "num of threads");
+    public static final ConfigArgOption ARG_SHORT_BENCHMARK =
+        of("benchmark", "benchmark", "Fast loading benchmark data (dafault NONE).", "NONE | TPCH");
+    public static final ConfigArgOption ARG_SHORT_SCALE =
+        of("scale", "scale", "The size scale benchmark data (GB for tpch).", "size");
 
     public boolean hasArg() {
         return argName != null;

--- a/batch-tool/src/main/java/exec/BaseExecutor.java
+++ b/batch-tool/src/main/java/exec/BaseExecutor.java
@@ -225,7 +225,7 @@ public abstract class BaseExecutor {
         producerThreadPool.shutdown();
     }
 
-    private int getConsumerNum(ConsumerExecutionContext consumerExecutionContext) {
+    protected int getConsumerNum(ConsumerExecutionContext consumerExecutionContext) {
         if (!consumerExecutionContext.isForceParallelism()) {
             return Math.max(consumerExecutionContext.getParallelism(),
                 ConfigConstant.CPU_NUM);
@@ -305,9 +305,13 @@ public abstract class BaseExecutor {
                                  ConsumerExecutionContext consumerContext) {
         try {
             // 等待生产者结束
-            while (!countDownLatch.await(10, TimeUnit.SECONDS)) {
+            while (!countDownLatch.await(3, TimeUnit.SECONDS)) {
                 if (producerContext.getException() != null) {
                     logger.warn("Early exit because of producer exception");
+                    return;
+                }
+                if (consumerContext.getException() != null) {
+                    logger.warn("Early exit because of consumer exception");
                     return;
                 }
             }

--- a/batch-tool/src/main/java/exec/ImportExecutor.java
+++ b/batch-tool/src/main/java/exec/ImportExecutor.java
@@ -112,7 +112,7 @@ public class ImportExecutor extends WriteDbExecutor {
     @Override
     public void execute() {
         if (producerExecutionContext.getBenchmarkMode() != BenchmarkMode.NONE) {
-            handleBenchmark();
+            handleBenchmark(tableNames);
             return;
         }
 
@@ -161,10 +161,10 @@ public class ImportExecutor extends WriteDbExecutor {
         }
     }
 
-    private void handleBenchmark() {
+    private void handleBenchmark(List<String> tableNames) {
         switch (producerExecutionContext.getBenchmarkMode()) {
         case TPCH:
-            handleTpchImport();
+            handleTpchImport(tableNames);
             break;
         default:
             throw new UnsupportedOperationException("Not support " + producerExecutionContext.getBenchmarkMode());
@@ -172,7 +172,7 @@ public class ImportExecutor extends WriteDbExecutor {
 
     }
 
-    private void handleTpchImport() {
+    private void handleTpchImport(List<String> tableNames) {
         int producerParallelism = producerExecutionContext.getParallelism();
         AtomicInteger emittedDataCounter = new AtomicInteger(0);
 
@@ -191,7 +191,7 @@ public class ImportExecutor extends WriteDbExecutor {
         EventFactory<BatchInsertSqlEvent> factory = BatchInsertSqlEvent::new;
         RingBuffer<BatchInsertSqlEvent> ringBuffer = MyWorkerPool.createRingBuffer(factory);
 
-        TpchProducer tpchProducer = new TpchProducer(producerExecutionContext, ringBuffer);
+        TpchProducer tpchProducer = new TpchProducer(producerExecutionContext, tableNames, ringBuffer);
         CountDownLatch countDownLatch = new CountDownLatch(tpchProducer.getWorkerCount());
         producerExecutionContext.setCountDownLatch(countDownLatch);
 

--- a/batch-tool/src/main/java/model/ProducerExecutionContext.java
+++ b/batch-tool/src/main/java/model/ProducerExecutionContext.java
@@ -17,6 +17,7 @@
 package model;
 
 import model.config.BaseConfig;
+import model.config.BenchmarkMode;
 import model.config.ConfigConstant;
 import model.config.FileLineRecord;
 import model.config.QuoteEncloseMode;
@@ -68,6 +69,13 @@ public class ProducerExecutionContext extends BaseConfig {
     private CountDownLatch countDownLatch;
 
     private volatile Exception exception;
+
+    protected BenchmarkMode benchmarkMode;
+
+    /**
+     * Benchmark 数据集的规模
+     */
+    protected int scale;
 
     public ProducerExecutionContext() {
         super(ConfigConstant.DEFAULT_IMPORT_SHARDING_ENABLED);
@@ -244,6 +252,22 @@ public class ProducerExecutionContext extends BaseConfig {
 
     public void setException(Exception exception) {
         this.exception = exception;
+    }
+
+    public BenchmarkMode getBenchmarkMode() {
+        return benchmarkMode;
+    }
+
+    public void setBenchmarkMode(BenchmarkMode benchmarkMode) {
+        this.benchmarkMode = benchmarkMode;
+    }
+
+    public int getScale() {
+        return scale;
+    }
+
+    public void setScale(int scale) {
+        this.scale = scale;
     }
 
     public boolean isTrimRight() {

--- a/batch-tool/src/main/java/model/config/BenchmarkMode.java
+++ b/batch-tool/src/main/java/model/config/BenchmarkMode.java
@@ -16,27 +16,25 @@
 
 package model.config;
 
-public class GlobalVar {
+import org.apache.commons.lang.StringUtils;
 
-    /**
-     * 发送一批数据的元组数
-     */
-    public static int EMIT_BATCH_SIZE = 100;
+public enum BenchmarkMode {
 
-    /**
-     * RingBuffer 缓冲区大小
-     */
-    public static int DEFAULT_RING_BUFFER_SIZE = 1024;
+    TPCH,
+    NONE;
 
-    /**
-     * 每个worker线程可分配的堆外内存
-     * 4K
-     */
-    public static int DEFAULT_DIRECT_BUFFER_SIZE_PER_WORKER = 1024 * 4;
-
-    public static boolean IN_PERF_MODE = false;
-
-    public static int DDL_RETRY_COUNT = 5;
-
-    public static int DDL_PARALLELISM = 10;
+    public static BenchmarkMode parseMode(String mode) {
+        if (StringUtils.isBlank(mode)) {
+            return NONE;
+        }
+        switch (mode.toLowerCase()) {
+        case "tpch":
+        case "tpc-h":
+            return TPCH;
+        case "none":
+            return NONE;
+        default:
+            throw new IllegalArgumentException("Unsupported benchmark mode: " + mode);
+        }
+    }
 }

--- a/batch-tool/src/main/java/model/config/GlobalVar.java
+++ b/batch-tool/src/main/java/model/config/GlobalVar.java
@@ -21,7 +21,7 @@ public class GlobalVar {
     /**
      * 发送一批数据的元组数
      */
-    public static int EMIT_BATCH_SIZE = 100;
+    public static int EMIT_BATCH_SIZE = 5;
 
     /**
      * RingBuffer 缓冲区大小

--- a/batch-tool/src/main/java/model/config/GlobalVar.java
+++ b/batch-tool/src/main/java/model/config/GlobalVar.java
@@ -39,4 +39,6 @@ public class GlobalVar {
     public static int DDL_RETRY_COUNT = 5;
 
     public static int DDL_PARALLELISM = 10;
+
+    public static final boolean DEBUG_MODE = false;
 }

--- a/batch-tool/src/main/java/worker/MyThreadPool.java
+++ b/batch-tool/src/main/java/worker/MyThreadPool.java
@@ -66,5 +66,15 @@ public class MyThreadPool {
             new LinkedBlockingQueue<>(QUEUE_SIZE),
             new NamedThreadFactory(name, false));
     }
+
+    public static ThreadPoolExecutor createExecutorExact(String name, int coreSize) {
+        return new ThreadPoolExecutor(
+            coreSize,
+            coreSize,
+            ALIVE_TIME,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(QUEUE_SIZE),
+            new NamedThreadFactory(name, false));
+    }
 }
 

--- a/batch-tool/src/main/java/worker/common/Producer.java
+++ b/batch-tool/src/main/java/worker/common/Producer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.common;
+
+public interface Producer {
+    void produce();
+}

--- a/batch-tool/src/main/java/worker/common/ReadFileProducer.java
+++ b/batch-tool/src/main/java/worker/common/ReadFileProducer.java
@@ -27,7 +27,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class ReadFileProducer {
+public abstract class ReadFileProducer implements Producer {
 
     private static final Logger logger = LoggerFactory.getLogger(ReadFileProducer.class);
 

--- a/batch-tool/src/main/java/worker/tpch/BatchInsertSqlEvent.java
+++ b/batch-tool/src/main/java/worker/tpch/BatchInsertSqlEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch;
+
+/**
+ * batch insert SQL
+ */
+public class BatchInsertSqlEvent {
+
+    public String getSql() {
+        return sql;
+    }
+
+    public void setSql(String sql) {
+        this.sql = sql;
+    }
+
+    private String sql;
+
+}

--- a/batch-tool/src/main/java/worker/tpch/TpchConsumer.java
+++ b/batch-tool/src/main/java/worker/tpch/TpchConsumer.java
@@ -42,8 +42,8 @@ public class TpchConsumer implements WorkHandler<BatchInsertSqlEvent> {
             Statement stmt = conn.createStatement()) {
             stmt.execute(sql);
         } catch (SQLException e) {
-            logger.error(sql + ", due to " + e.getMessage());
-//            logger.error(sql.substring(0, Math.min(32, sql.length())) + ", due to" + e.getMessage());
+//            logger.error(sql + ", due to " + e.getMessage());
+            logger.error(sql.substring(0, Math.min(32, sql.length())) + ", due to" + e.getMessage());
             consumerContext.setException(e);
             throw new RuntimeException(e);
         } finally {

--- a/batch-tool/src/main/java/worker/tpch/TpchConsumer.java
+++ b/batch-tool/src/main/java/worker/tpch/TpchConsumer.java
@@ -18,6 +18,7 @@ package worker.tpch;
 
 import com.lmax.disruptor.WorkHandler;
 import model.ConsumerExecutionContext;
+import model.config.GlobalVar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,10 +42,12 @@ public class TpchConsumer implements WorkHandler<BatchInsertSqlEvent> {
         try (Connection conn = consumerContext.getDataSource().getConnection();
             Statement stmt = conn.createStatement()) {
             stmt.execute(sql);
-//            System.out.println(sql);
         } catch (SQLException e) {
-            logger.error(sql + ", due to " + e.getMessage());
-//            logger.error(sql.substring(0, Math.min(32, sql.length())) + ", due to" + e.getMessage());
+            if (GlobalVar.DEBUG_MODE) {
+                logger.error(sql + ", due to " + e.getMessage());
+            } else {
+                logger.error(sql.substring(0, Math.min(32, sql.length())) + ", due to" + e.getMessage());
+            }
             consumerContext.setException(e);
             throw new RuntimeException(e);
         } finally {

--- a/batch-tool/src/main/java/worker/tpch/TpchConsumer.java
+++ b/batch-tool/src/main/java/worker/tpch/TpchConsumer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch;
+
+import com.lmax.disruptor.WorkHandler;
+import model.ConsumerExecutionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class TpchConsumer implements WorkHandler<BatchInsertSqlEvent> {
+
+    private static final Logger logger = LoggerFactory.getLogger(TpchConsumer.class);
+
+    protected final ConsumerExecutionContext consumerContext;
+
+    public TpchConsumer(ConsumerExecutionContext consumerContext) {
+        this.consumerContext = consumerContext;
+    }
+
+    @Override
+    public void onEvent(BatchInsertSqlEvent event) {
+        String sql = event.getSql();
+        try (Connection conn = consumerContext.getDataSource().getConnection();
+            Statement stmt = conn.createStatement()) {
+            stmt.execute(sql);
+        } catch (SQLException e) {
+            logger.error(sql + ", due to " + e.getMessage());
+//            logger.error(sql.substring(0, Math.min(32, sql.length())) + ", due to" + e.getMessage());
+            consumerContext.setException(e);
+            throw new RuntimeException(e);
+        } finally {
+            consumerContext.getEmittedDataCounter().decrementAndGet();
+        }
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/TpchConsumer.java
+++ b/batch-tool/src/main/java/worker/tpch/TpchConsumer.java
@@ -41,9 +41,10 @@ public class TpchConsumer implements WorkHandler<BatchInsertSqlEvent> {
         try (Connection conn = consumerContext.getDataSource().getConnection();
             Statement stmt = conn.createStatement()) {
             stmt.execute(sql);
+//            System.out.println(sql);
         } catch (SQLException e) {
-//            logger.error(sql + ", due to " + e.getMessage());
-            logger.error(sql.substring(0, Math.min(32, sql.length())) + ", due to" + e.getMessage());
+            logger.error(sql + ", due to " + e.getMessage());
+//            logger.error(sql.substring(0, Math.min(32, sql.length())) + ", due to" + e.getMessage());
             consumerContext.setException(e);
             throw new RuntimeException(e);
         } finally {

--- a/batch-tool/src/main/java/worker/tpch/TpchProducer.java
+++ b/batch-tool/src/main/java/worker/tpch/TpchProducer.java
@@ -1,0 +1,516 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch;
+
+import com.lmax.disruptor.RingBuffer;
+import io.airlift.tpch.Customer;
+import io.airlift.tpch.LineItem;
+import io.airlift.tpch.Nation;
+import io.airlift.tpch.Order;
+import io.airlift.tpch.Part;
+import io.airlift.tpch.PartSupplier;
+import io.airlift.tpch.Region;
+import io.airlift.tpch.Supplier;
+import io.airlift.tpch.TpchTable;
+import model.ProducerExecutionContext;
+import org.apache.commons.lang.time.FastDateFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import worker.common.Producer;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static model.config.GlobalVar.EMIT_BATCH_SIZE;
+
+public class TpchProducer implements Producer {
+
+    private static final Logger logger = LoggerFactory.getLogger(TpchProducer.class);
+
+    private final ProducerExecutionContext context;
+    private final RingBuffer<BatchInsertSqlEvent> ringBuffer;
+    private final ThreadPoolExecutor executor;
+    private final int scale;
+    private int workerCount;
+
+    private Map<TpchTableModel, List<Iterator>> tableIteratorsMap;
+
+    public TpchProducer(ProducerExecutionContext context, RingBuffer<BatchInsertSqlEvent> ringBuffer) {
+        this.context = context;
+        this.ringBuffer = ringBuffer;
+
+        this.scale = context.getScale();
+        if (scale <= 0) {
+            throw new IllegalArgumentException("Scale must be a positive integer");
+        }
+        this.executor = context.getProducerExecutor();
+
+        this.tableIteratorsMap = new HashMap<>();
+        initIterators();
+        initWorkerCount();
+    }
+
+    private void initIterators() {
+        addRegionIterator();
+        addNationIterator();
+        addCustomerIterator();
+        addPartIterator();
+        addSupplierIterator();
+        addPartSuppIterator();
+        addOrdersIterator();
+        addLineitemIterator();
+    }
+
+    private void initWorkerCount() {
+        this.workerCount = tableIteratorsMap.values().stream()
+            .mapToInt(List::size).sum();
+    }
+
+    public int getWorkerCount() {
+        return this.workerCount;
+    }
+
+    private void addRegionIterator() {
+        List<Iterator> regionIters = new ArrayList<>(1);
+        regionIters.add(TpchTable.REGION.createGenerator(scale, 1, 1).iterator());
+        this.tableIteratorsMap.put(TpchTableModel.REGION, regionIters);
+    }
+
+    private void addNationIterator() {
+        List<Iterator> nationIters = new ArrayList<>(1);
+        nationIters.add(TpchTable.NATION.createGenerator(scale, 1, 1).iterator());
+        this.tableIteratorsMap.put(TpchTableModel.NATION, nationIters);
+    }
+
+    private void addCustomerIterator() {
+        int customerPart;
+        if (scale < 10) {
+            customerPart = 1;
+        } else {
+            customerPart = 4;
+        }
+
+        List<Iterator> customerIters = new ArrayList<>(customerPart);
+        for (int i = 1; i <= customerPart; i++) {
+            customerIters.add(TpchTable.CUSTOMER.createGenerator(scale, i, customerPart).iterator());
+            this.tableIteratorsMap.put(TpchTableModel.CUSTOMER, customerIters);
+        }
+    }
+
+    private void addPartIterator() {
+        int partPart;
+        if (scale < 10) {
+            partPart = 1;
+        } else {
+            partPart = 5;
+        }
+
+        List<Iterator> partIters = new ArrayList<>(partPart);
+        for (int i = 1; i <= partPart; i++) {
+            partIters.add(TpchTable.PART.createGenerator(scale, i, partPart).iterator());
+            this.tableIteratorsMap.put(TpchTableModel.PART, partIters);
+        }
+    }
+
+    private void addSupplierIterator() {
+        final int supplierPart = 1;
+
+        List<Iterator> supplierIters = new ArrayList<>(supplierPart);
+        for (int i = 1; i <= supplierPart; i++) {
+            supplierIters.add(TpchTable.SUPPLIER.createGenerator(scale, i, supplierPart).iterator());
+            this.tableIteratorsMap.put(TpchTableModel.SUPPLIER, supplierIters);
+        }
+    }
+
+    /**
+     * 第三大表
+     */
+    private void addPartSuppIterator() {
+        int partSuppPart;
+        if (scale < 10) {
+            partSuppPart = 4;
+        } else {
+            partSuppPart = 20;
+        }
+
+        List<Iterator> partSuppIters = new ArrayList<>(partSuppPart);
+        for (int i = 1; i <= partSuppPart; i++) {
+            partSuppIters.add(TpchTable.PART_SUPPLIER.createGenerator(scale, i, partSuppPart).iterator());
+            this.tableIteratorsMap.put(TpchTableModel.PART_SUPP, partSuppIters);
+        }
+    }
+
+    /**
+     * 第二大表
+     */
+    private void addOrdersIterator() {
+        int ordersPart;
+        if (scale < 10) {
+            ordersPart = 8;
+        } else {
+            ordersPart = 40;
+        }
+
+        List<Iterator> ordersIters = new ArrayList<>(ordersPart);
+        for (int i = 1; i <= ordersPart; i++) {
+            ordersIters.add(TpchTable.ORDERS.createGenerator(scale, i, ordersPart).iterator());
+            this.tableIteratorsMap.put(TpchTableModel.ORDERS, ordersIters);
+        }
+    }
+
+    /**
+     * 第一大表
+     * 此处暂不考虑生产者线程池太大导致生产者空闲
+     */
+    private void addLineitemIterator() {
+        int lineitemPart;
+        if (scale < 10) {
+            lineitemPart = 16;
+        } else {
+            lineitemPart = 80;
+        }
+
+        List<Iterator> lineitemIters = new ArrayList<>(lineitemPart);
+        for (int i = 1; i <= lineitemPart; i++) {
+            lineitemIters.add(TpchTable.LINE_ITEM.createGenerator(scale, i, lineitemPart).iterator());
+            this.tableIteratorsMap.put(TpchTableModel.LINEITEM, lineitemIters);
+        }
+    }
+
+    @Override
+    public void produce() {
+        boolean hasNext = true;
+        Map<TpchTableModel, Iterator<Iterator>> iteratorMap = new HashMap<>(32);
+        for (Map.Entry<TpchTableModel, List<Iterator>> entry : tableIteratorsMap.entrySet()) {
+            iteratorMap.put(entry.getKey(), entry.getValue().iterator());
+        }
+
+        Map<TpchTableModel, Integer> partMap = new HashMap<>(32);
+
+        // 按表依次提交任务
+        while (hasNext) {
+            hasNext = false;
+            for (Map.Entry<TpchTableModel, Iterator<Iterator>> entry : iteratorMap.entrySet()) {
+                if (entry.getValue().hasNext()) {
+                    hasNext = true;
+                    int part = partMap.getOrDefault(entry.getKey(), 1);
+
+                    Iterator nextTableIter = entry.getValue().next();
+                    TpchTableWorker<?> producer = buildProducer(entry.getKey(), nextTableIter, part);
+                    executor.submit(producer);
+
+                    partMap.put(entry.getKey(), part + 1);
+                }
+            }
+        }
+
+    }
+
+    private TpchTableWorker<?> buildProducer(TpchTableModel table, Iterator nextTableIter, int part) {
+        switch (table) {
+        case LINEITEM:
+            return buildLineitemProducer(table, nextTableIter, part);
+        case CUSTOMER:
+            return buildCustomerProducer(table, nextTableIter, part);
+        case ORDERS:
+            return buildOrdersProducer(table, nextTableIter, part);
+        case PART:
+            return buildPartProducer(table, nextTableIter, part);
+        case SUPPLIER:
+            return buildSupplierProducer(table, nextTableIter, part);
+        case PART_SUPP:
+            return buildPartSuppProducer(table, nextTableIter, part);
+        case NATION:
+            return buildNationProducer(table, nextTableIter, part);
+        case REGION:
+            return buildRegionWorker(table, nextTableIter, part);
+        }
+        throw new UnsupportedOperationException("Unsupported TPC-H table: " + table);
+    }
+
+    /**
+     * 转为两位小数的字符串表示
+     * 并append
+     */
+    private void appendDecimalWithFrac2(StringBuilder sqlBuffer, long l) {
+        long intPart = l / 100;
+        long fracPart = l % 100;
+        sqlBuffer.append(intPart).append('.').append(fracPart);
+    }
+
+    private TpchTableWorker<?> buildLineitemProducer(TpchTableModel table, Iterator nextTableIter, int part) {
+        TpchTableWorker<LineItem> lineitemProducer = new TpchTableWorker<LineItem>(ringBuffer, nextTableIter,
+            table.getName(), table.getRowStrLen(), part) {
+            @Override
+            protected void appendToBuffer(LineItem row) {
+
+                this.sqlBuffer.append('(').append(row.getOrderKey())
+                    .append(',').append(row.getPartKey())
+                    .append(',').append(row.getSupplierKey())
+                    .append(',').append(row.getLineNumber())
+                    .append(',').append(row.getQuantity())
+                    .append(",");
+
+                appendDecimalWithFrac2(this.sqlBuffer, row.getExtendedPriceInCents());
+                this.sqlBuffer.append(',');
+                appendDecimalWithFrac2(this.sqlBuffer, row.getDiscountPercent());
+                this.sqlBuffer.append(',');
+                appendDecimalWithFrac2(this.sqlBuffer, row.getTaxPercent());
+
+                this.sqlBuffer.append(",\"").append(row.getReturnFlag())
+                    .append("\",\"").append(row.getStatus())
+                    .append("\",\"").append(formatDate(row.getShipDate()))
+                    .append("\",\"").append(formatDate(row.getCommitDate()))
+                    .append("\",\"").append(formatDate(row.getReceiptDate()))
+                    .append("\",\"").append(row.getShipInstructions())
+                    .append("\",\"").append(row.getShipMode())
+                    .append("\",\"").append(row.getComment()).append("\"),");
+
+            }
+        };
+        return lineitemProducer;
+    }
+
+    private TpchTableWorker<?> buildCustomerProducer(TpchTableModel table, Iterator nextTableIter, int part) {
+        TpchTableWorker<Customer> customerProducer = new TpchTableWorker<Customer>(ringBuffer, nextTableIter,
+            table.getName(), table.getRowStrLen(), part) {
+            @Override
+            protected void appendToBuffer(Customer row) {
+                this.sqlBuffer.append('(').append(row.getCustomerKey())
+                    .append(",\"").append(row.getName())
+                    .append("\",\"").append(row.getAddress())
+                    .append("\",").append(row.getNationKey())
+                    .append(",\"").append(row.getPhone())
+                    .append("\",");
+
+                appendDecimalWithFrac2(this.sqlBuffer, row.getAccountBalanceInCents());
+
+                this.sqlBuffer.append(",\"").append(row.getMarketSegment())
+                    .append("\",\"").append(row.getComment()).append("\"),");
+            }
+        };
+        return customerProducer;
+    }
+
+    private TpchTableWorker<?> buildOrdersProducer(TpchTableModel table, Iterator nextTableIter, int part) {
+        TpchTableWorker<Order> orderProducer = new TpchTableWorker<Order>(ringBuffer, nextTableIter,
+            table.getName(), table.getRowStrLen(), part) {
+            @Override
+            protected void appendToBuffer(Order row) {
+
+                this.sqlBuffer.append('(').append(row.getOrderKey())
+                    .append(',').append(row.getCustomerKey())
+                    .append(",\"").append(row.getOrderStatus())
+                    .append("\",");
+
+                appendDecimalWithFrac2(this.sqlBuffer, row.getTotalPriceInCents());
+
+                this.sqlBuffer.append(",\"").append(formatDate(row.getOrderDate()))
+                    .append("\",\"").append(row.getOrderPriority())
+                    .append("\",\"").append(row.getClerk())
+                    .append("\",").append(row.getShipPriority())
+                    .append(",\"").append(row.getComment()).append("\"),");
+            }
+        };
+        return orderProducer;
+    }
+
+    private TpchTableWorker<?> buildPartProducer(TpchTableModel table, Iterator nextTableIter, int part) {
+        TpchTableWorker<Part> partProducer = new TpchTableWorker<Part>(ringBuffer, nextTableIter,
+            table.getName(), table.getRowStrLen(), part) {
+            @Override
+            protected void appendToBuffer(Part row) {
+
+                this.sqlBuffer.append('(').append(row.getPartKey())
+                    .append(",\"").append(row.getName())
+                    .append("\",\"").append(row.getManufacturer())
+                    .append("\",\"").append(row.getBrand())
+                    .append("\",\"").append(row.getType())
+                    .append("\",").append(row.getSize())
+                    .append(",\"").append(row.getContainer())
+                    .append("\",");
+
+                appendDecimalWithFrac2(this.sqlBuffer, row.getRetailPriceInCents());
+
+                this.sqlBuffer.append(",\"").append(row.getComment()).append("\"),");
+            }
+        };
+        return partProducer;
+    }
+
+    private TpchTableWorker<?> buildSupplierProducer(TpchTableModel table, Iterator nextTableIter, int part) {
+        TpchTableWorker<Supplier> supplierProducer = new TpchTableWorker<Supplier>(ringBuffer, nextTableIter,
+            table.getName(), table.getRowStrLen(), part) {
+            @Override
+            protected void appendToBuffer(Supplier row) {
+
+                this.sqlBuffer.append('(').append(row.getSupplierKey())
+                    .append(",\"").append(row.getName())
+                    .append("\",\"").append(row.getAddress())
+                    .append("\",").append(row.getNationKey())
+                    .append(",\"").append(row.getPhone())
+                    .append("\",");
+
+                appendDecimalWithFrac2(this.sqlBuffer, row.getAccountBalanceInCents());
+
+                this.sqlBuffer.append(",\"").append(row.getComment()).append("\"),");
+            }
+        };
+        return supplierProducer;
+    }
+
+    private TpchTableWorker<?> buildPartSuppProducer(TpchTableModel table, Iterator nextTableIter, int part) {
+        TpchTableWorker<PartSupplier> partSuppProducer = new TpchTableWorker<PartSupplier>(ringBuffer, nextTableIter,
+            table.getName(), table.getRowStrLen(), part) {
+            @Override
+            protected void appendToBuffer(PartSupplier row) {
+
+                this.sqlBuffer.append('(').append(row.getPartKey())
+                    .append(',').append(row.getSupplierKey())
+                    .append(',').append(row.getAvailableQuantity())
+                    .append(',');
+
+                appendDecimalWithFrac2(this.sqlBuffer, row.getSupplyCostInCents());
+
+                this.sqlBuffer.append(",\"").append(row.getComment()).append("\"),");
+            }
+        };
+        return partSuppProducer;
+    }
+
+    private TpchTableWorker<?> buildNationProducer(TpchTableModel table, Iterator nextTableIter, int part) {
+        TpchTableWorker<Nation> nationProducer = new TpchTableWorker<Nation>(ringBuffer, nextTableIter,
+            table.getName(), table.getRowStrLen(), part) {
+            @Override
+            protected void appendToBuffer(Nation row) {
+                this.sqlBuffer.append('(').append(row.getNationKey())
+                    .append(",\"").append(row.getName())
+                    .append("\",").append(row.getRegionKey())
+                    .append(",\"").append(row.getComment()).append("\"),");
+            }
+        };
+        return nationProducer;
+    }
+
+    private TpchTableWorker<?> buildRegionWorker(TpchTableModel table, Iterator nextTableIter, int part) {
+        TpchTableWorker<Region> regionProducer = new TpchTableWorker<Region>(ringBuffer, nextTableIter,
+            table.getName(), table.getRowStrLen(), part) {
+            @Override
+            protected void appendToBuffer(Region row) {
+                this.sqlBuffer.append('(').append(row.getRegionKey())
+                    .append(",\"").append(row.getName())
+                    .append("\",\"").append(row.getComment()).append("\"),");
+            }
+        };
+        return regionProducer;
+    }
+
+    /**
+     * 尽可能同时并发写入不同的表
+     */
+    abstract class TpchTableWorker<T> implements Runnable {
+        protected final RingBuffer<BatchInsertSqlEvent> ringBuffer;
+        protected final StringBuilder sqlBuffer;
+        protected final Iterator<T> iterator;
+        protected final String tableName;
+        protected final int estimateRowLen;
+        protected final int part;
+        protected final FastDateFormat dateFormat = FastDateFormat.getInstance("yyyy-MM-dd");
+        protected int bufferedLineCount = 0;
+
+        TpchTableWorker(RingBuffer<BatchInsertSqlEvent> ringBuffer, Iterator<T> iterator,
+                        String tableName, int estimateRowLen) {
+            this(ringBuffer, iterator, tableName, estimateRowLen, 0);
+        }
+
+        TpchTableWorker(RingBuffer<BatchInsertSqlEvent> ringBuffer, Iterator<T> iterator,
+                        String tableName, int estimateRowLen, int part) {
+            this.ringBuffer = ringBuffer;
+            this.iterator = iterator;
+            this.tableName = tableName;
+            this.estimateRowLen = estimateRowLen;
+            this.part = part;
+
+            this.sqlBuffer = new StringBuilder("INSERT INTO  VALUES ()".length() +
+                this.tableName.length() + EMIT_BATCH_SIZE * (2 + estimateRowLen));
+            refreshBuffer();
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (iterator.hasNext()) {
+                    T row = iterator.next();
+                    appendToBuffer(row);
+                    bufferedLineCount++;
+                    if (bufferedLineCount >= EMIT_BATCH_SIZE) {
+                        emitLineBuffer();
+                    }
+                }
+                if (bufferedLineCount != 0) {
+                    emitLineBuffer();
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                context.getCountDownLatch().countDown();
+                logger.info("{}-{} produce done", tableName, part);
+            }
+        }
+
+        /**
+         * TODO 可以自己实现这个逻辑并优化
+         * 返回格式 yyyy-MM-dd
+         *
+         * @param days 自从1970-01-01经过的天数
+         */
+        String formatDate(int days) {
+            Date date = new Date(TimeUnit.DAYS.toMillis(days));
+            return dateFormat.format(date);
+        }
+
+        protected abstract void appendToBuffer(T row);
+
+        protected void emitLineBuffer() {
+            System.out.println("Remain buffer: " + ringBuffer.remainingCapacity());
+            long sequence = ringBuffer.next();
+            BatchInsertSqlEvent event;
+            try {
+                event = ringBuffer.get(sequence);
+                sqlBuffer.setCharAt(sqlBuffer.length() - 1, ';');   // 最后一个逗号替换为分号
+                String sql = sqlBuffer.toString();
+                event.setSql(sql);
+                refreshBuffer();
+            } finally {
+                bufferedLineCount = 0;
+                context.getEmittedDataCounter().getAndIncrement();
+                ringBuffer.publish(sequence);
+            }
+        }
+
+        private void refreshBuffer() {
+            sqlBuffer.setLength(0);
+            sqlBuffer.append("INSERT INTO `").append(tableName).append("` VALUES ");
+        }
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/TpchProducer.java
+++ b/batch-tool/src/main/java/worker/tpch/TpchProducer.java
@@ -277,11 +277,6 @@ public class TpchProducer implements Producer {
         protected int bufferedLineCount = 0;
 
         TpchTableWorker(RingBuffer<BatchInsertSqlEvent> ringBuffer, TableRowGenerator rowGenerator,
-                        String tableName, int estimateRowLen) {
-            this(ringBuffer, rowGenerator, tableName, estimateRowLen, 0);
-        }
-
-        TpchTableWorker(RingBuffer<BatchInsertSqlEvent> ringBuffer, TableRowGenerator rowGenerator,
                         String tableName, int estimateRowLen, int part) {
             this.ringBuffer = ringBuffer;
             this.rowGenerator = rowGenerator;

--- a/batch-tool/src/main/java/worker/tpch/TpchProducer.java
+++ b/batch-tool/src/main/java/worker/tpch/TpchProducer.java
@@ -492,7 +492,6 @@ public class TpchProducer implements Producer {
         protected abstract void appendToBuffer(T row);
 
         protected void emitLineBuffer() {
-            System.out.println("Remain buffer: " + ringBuffer.remainingCapacity());
             long sequence = ringBuffer.next();
             BatchInsertSqlEvent event;
             try {

--- a/batch-tool/src/main/java/worker/tpch/TpchProducer.java
+++ b/batch-tool/src/main/java/worker/tpch/TpchProducer.java
@@ -17,29 +17,26 @@
 package worker.tpch;
 
 import com.lmax.disruptor.RingBuffer;
-import io.airlift.tpch.Customer;
-import io.airlift.tpch.LineItem;
-import io.airlift.tpch.Nation;
-import io.airlift.tpch.Order;
-import io.airlift.tpch.Part;
-import io.airlift.tpch.PartSupplier;
-import io.airlift.tpch.Region;
-import io.airlift.tpch.Supplier;
-import io.airlift.tpch.TpchTable;
 import model.ProducerExecutionContext;
-import org.apache.commons.lang.time.FastDateFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import worker.common.Producer;
+import worker.tpch.generator.CustomerGenerator;
+import worker.tpch.generator.LineItemGenerator;
+import worker.tpch.generator.NationGenerator;
+import worker.tpch.generator.OrderGenerator;
+import worker.tpch.generator.PartGenerator;
+import worker.tpch.generator.PartSupplierGenerator;
+import worker.tpch.generator.RegionGenerator;
+import worker.tpch.generator.SupplierGenerator;
+import worker.tpch.generator.TableRowGenerator;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import static model.config.GlobalVar.EMIT_BATCH_SIZE;
 
@@ -53,7 +50,7 @@ public class TpchProducer implements Producer {
     private final int scale;
     private int workerCount;
 
-    private Map<TpchTableModel, List<Iterator>> tableIteratorsMap;
+    private Map<TpchTableModel, List<TableRowGenerator>> tableGeneratorsMap;
 
     public TpchProducer(ProducerExecutionContext context, RingBuffer<BatchInsertSqlEvent> ringBuffer) {
         this.context = context;
@@ -65,7 +62,7 @@ public class TpchProducer implements Producer {
         }
         this.executor = context.getProducerExecutor();
 
-        this.tableIteratorsMap = new HashMap<>();
+        this.tableGeneratorsMap = new HashMap<>();
         initIterators();
         initWorkerCount();
     }
@@ -82,7 +79,7 @@ public class TpchProducer implements Producer {
     }
 
     private void initWorkerCount() {
-        this.workerCount = tableIteratorsMap.values().stream()
+        this.workerCount = tableGeneratorsMap.values().stream()
             .mapToInt(List::size).sum();
     }
 
@@ -91,15 +88,15 @@ public class TpchProducer implements Producer {
     }
 
     private void addRegionIterator() {
-        List<Iterator> regionIters = new ArrayList<>(1);
-        regionIters.add(TpchTable.REGION.createGenerator(scale, 1, 1).iterator());
-        this.tableIteratorsMap.put(TpchTableModel.REGION, regionIters);
+        List<TableRowGenerator> regionIters = new ArrayList<>(1);
+        regionIters.add(new RegionGenerator());
+        this.tableGeneratorsMap.put(TpchTableModel.REGION, regionIters);
     }
 
     private void addNationIterator() {
-        List<Iterator> nationIters = new ArrayList<>(1);
-        nationIters.add(TpchTable.NATION.createGenerator(scale, 1, 1).iterator());
-        this.tableIteratorsMap.put(TpchTableModel.NATION, nationIters);
+        List<TableRowGenerator> nationIters = new ArrayList<>(1);
+        nationIters.add(new NationGenerator());
+        this.tableGeneratorsMap.put(TpchTableModel.NATION, nationIters);
     }
 
     private void addCustomerIterator() {
@@ -110,10 +107,10 @@ public class TpchProducer implements Producer {
             customerPart = 4;
         }
 
-        List<Iterator> customerIters = new ArrayList<>(customerPart);
+        List<TableRowGenerator> customerIters = new ArrayList<>(customerPart);
         for (int i = 1; i <= customerPart; i++) {
-            customerIters.add(TpchTable.CUSTOMER.createGenerator(scale, i, customerPart).iterator());
-            this.tableIteratorsMap.put(TpchTableModel.CUSTOMER, customerIters);
+            customerIters.add(new CustomerGenerator(scale, i, customerPart));
+            this.tableGeneratorsMap.put(TpchTableModel.CUSTOMER, customerIters);
         }
     }
 
@@ -125,20 +122,20 @@ public class TpchProducer implements Producer {
             partPart = 5;
         }
 
-        List<Iterator> partIters = new ArrayList<>(partPart);
+        List<TableRowGenerator> partIters = new ArrayList<>(partPart);
         for (int i = 1; i <= partPart; i++) {
-            partIters.add(TpchTable.PART.createGenerator(scale, i, partPart).iterator());
-            this.tableIteratorsMap.put(TpchTableModel.PART, partIters);
+            partIters.add(new PartGenerator(scale, i, partPart));
+            this.tableGeneratorsMap.put(TpchTableModel.PART, partIters);
         }
     }
 
     private void addSupplierIterator() {
         final int supplierPart = 1;
 
-        List<Iterator> supplierIters = new ArrayList<>(supplierPart);
+        List<TableRowGenerator> supplierIters = new ArrayList<>(supplierPart);
         for (int i = 1; i <= supplierPart; i++) {
-            supplierIters.add(TpchTable.SUPPLIER.createGenerator(scale, i, supplierPart).iterator());
-            this.tableIteratorsMap.put(TpchTableModel.SUPPLIER, supplierIters);
+            supplierIters.add(new SupplierGenerator(scale, i, supplierPart));
+            this.tableGeneratorsMap.put(TpchTableModel.SUPPLIER, supplierIters);
         }
     }
 
@@ -150,13 +147,13 @@ public class TpchProducer implements Producer {
         if (scale < 10) {
             partSuppPart = 4;
         } else {
-            partSuppPart = 20;
+            partSuppPart = 10;
         }
 
-        List<Iterator> partSuppIters = new ArrayList<>(partSuppPart);
+        List<TableRowGenerator> partSuppIters = new ArrayList<>(partSuppPart);
         for (int i = 1; i <= partSuppPart; i++) {
-            partSuppIters.add(TpchTable.PART_SUPPLIER.createGenerator(scale, i, partSuppPart).iterator());
-            this.tableIteratorsMap.put(TpchTableModel.PART_SUPP, partSuppIters);
+            partSuppIters.add(new PartSupplierGenerator(scale, i, partSuppPart));
+            this.tableGeneratorsMap.put(TpchTableModel.PART_SUPP, partSuppIters);
         }
     }
 
@@ -168,13 +165,13 @@ public class TpchProducer implements Producer {
         if (scale < 10) {
             ordersPart = 8;
         } else {
-            ordersPart = 40;
+            ordersPart = 30;
         }
 
-        List<Iterator> ordersIters = new ArrayList<>(ordersPart);
+        List<TableRowGenerator> ordersIters = new ArrayList<>(ordersPart);
         for (int i = 1; i <= ordersPart; i++) {
-            ordersIters.add(TpchTable.ORDERS.createGenerator(scale, i, ordersPart).iterator());
-            this.tableIteratorsMap.put(TpchTableModel.ORDERS, ordersIters);
+            ordersIters.add(new OrderGenerator(scale, i, ordersPart));
+            this.tableGeneratorsMap.put(TpchTableModel.ORDERS, ordersIters);
         }
     }
 
@@ -187,21 +184,21 @@ public class TpchProducer implements Producer {
         if (scale < 10) {
             lineitemPart = 16;
         } else {
-            lineitemPart = 80;
+            lineitemPart = 60;
         }
 
-        List<Iterator> lineitemIters = new ArrayList<>(lineitemPart);
+        List<TableRowGenerator> lineitemIters = new ArrayList<>(lineitemPart);
         for (int i = 1; i <= lineitemPart; i++) {
-            lineitemIters.add(TpchTable.LINE_ITEM.createGenerator(scale, i, lineitemPart).iterator());
-            this.tableIteratorsMap.put(TpchTableModel.LINEITEM, lineitemIters);
+            lineitemIters.add(new LineItemGenerator(scale, i, lineitemPart));
+            this.tableGeneratorsMap.put(TpchTableModel.LINEITEM, lineitemIters);
         }
     }
 
     @Override
     public void produce() {
         boolean hasNext = true;
-        Map<TpchTableModel, Iterator<Iterator>> iteratorMap = new HashMap<>(32);
-        for (Map.Entry<TpchTableModel, List<Iterator>> entry : tableIteratorsMap.entrySet()) {
+        Map<TpchTableModel, Iterator<TableRowGenerator>> iteratorMap = new HashMap<>(32);
+        for (Map.Entry<TpchTableModel, List<TableRowGenerator>> entry : tableGeneratorsMap.entrySet()) {
             iteratorMap.put(entry.getKey(), entry.getValue().iterator());
         }
 
@@ -210,13 +207,14 @@ public class TpchProducer implements Producer {
         // 按表依次提交任务
         while (hasNext) {
             hasNext = false;
-            for (Map.Entry<TpchTableModel, Iterator<Iterator>> entry : iteratorMap.entrySet()) {
+            for (Map.Entry<TpchTableModel, Iterator<TableRowGenerator>> entry : iteratorMap.entrySet()) {
                 if (entry.getValue().hasNext()) {
                     hasNext = true;
                     int part = partMap.getOrDefault(entry.getKey(), 1);
 
-                    Iterator nextTableIter = entry.getValue().next();
-                    TpchTableWorker<?> producer = buildProducer(entry.getKey(), nextTableIter, part);
+                    TableRowGenerator nextGenerator = entry.getValue().next();
+                    TpchTableWorker producer = new TpchTableWorker(ringBuffer,
+                        nextGenerator, entry.getKey().getName(), part);
                     executor.submit(producer);
 
                     partMap.put(entry.getKey(), part + 1);
@@ -226,227 +224,27 @@ public class TpchProducer implements Producer {
 
     }
 
-    private TpchTableWorker<?> buildProducer(TpchTableModel table, Iterator nextTableIter, int part) {
-        switch (table) {
-        case LINEITEM:
-            return buildLineitemProducer(table, nextTableIter, part);
-        case CUSTOMER:
-            return buildCustomerProducer(table, nextTableIter, part);
-        case ORDERS:
-            return buildOrdersProducer(table, nextTableIter, part);
-        case PART:
-            return buildPartProducer(table, nextTableIter, part);
-        case SUPPLIER:
-            return buildSupplierProducer(table, nextTableIter, part);
-        case PART_SUPP:
-            return buildPartSuppProducer(table, nextTableIter, part);
-        case NATION:
-            return buildNationProducer(table, nextTableIter, part);
-        case REGION:
-            return buildRegionWorker(table, nextTableIter, part);
-        }
-        throw new UnsupportedOperationException("Unsupported TPC-H table: " + table);
-    }
-
-    /**
-     * 转为两位小数的字符串表示
-     * 并append
-     */
-    private void appendDecimalWithFrac2(StringBuilder sqlBuffer, long l) {
-        long intPart = l / 100;
-        long fracPart = l % 100;
-        sqlBuffer.append(intPart).append('.').append(fracPart);
-    }
-
-    private TpchTableWorker<?> buildLineitemProducer(TpchTableModel table, Iterator nextTableIter, int part) {
-        TpchTableWorker<LineItem> lineitemProducer = new TpchTableWorker<LineItem>(ringBuffer, nextTableIter,
-            table.getName(), table.getRowStrLen(), part) {
-            @Override
-            protected void appendToBuffer(LineItem row) {
-
-                this.sqlBuffer.append('(').append(row.getOrderKey())
-                    .append(',').append(row.getPartKey())
-                    .append(',').append(row.getSupplierKey())
-                    .append(',').append(row.getLineNumber())
-                    .append(',').append(row.getQuantity())
-                    .append(",");
-
-                appendDecimalWithFrac2(this.sqlBuffer, row.getExtendedPriceInCents());
-                this.sqlBuffer.append(',');
-                appendDecimalWithFrac2(this.sqlBuffer, row.getDiscountPercent());
-                this.sqlBuffer.append(',');
-                appendDecimalWithFrac2(this.sqlBuffer, row.getTaxPercent());
-
-                this.sqlBuffer.append(",\"").append(row.getReturnFlag())
-                    .append("\",\"").append(row.getStatus())
-                    .append("\",\"").append(formatDate(row.getShipDate()))
-                    .append("\",\"").append(formatDate(row.getCommitDate()))
-                    .append("\",\"").append(formatDate(row.getReceiptDate()))
-                    .append("\",\"").append(row.getShipInstructions())
-                    .append("\",\"").append(row.getShipMode())
-                    .append("\",\"").append(row.getComment()).append("\"),");
-
-            }
-        };
-        return lineitemProducer;
-    }
-
-    private TpchTableWorker<?> buildCustomerProducer(TpchTableModel table, Iterator nextTableIter, int part) {
-        TpchTableWorker<Customer> customerProducer = new TpchTableWorker<Customer>(ringBuffer, nextTableIter,
-            table.getName(), table.getRowStrLen(), part) {
-            @Override
-            protected void appendToBuffer(Customer row) {
-                this.sqlBuffer.append('(').append(row.getCustomerKey())
-                    .append(",\"").append(row.getName())
-                    .append("\",\"").append(row.getAddress())
-                    .append("\",").append(row.getNationKey())
-                    .append(",\"").append(row.getPhone())
-                    .append("\",");
-
-                appendDecimalWithFrac2(this.sqlBuffer, row.getAccountBalanceInCents());
-
-                this.sqlBuffer.append(",\"").append(row.getMarketSegment())
-                    .append("\",\"").append(row.getComment()).append("\"),");
-            }
-        };
-        return customerProducer;
-    }
-
-    private TpchTableWorker<?> buildOrdersProducer(TpchTableModel table, Iterator nextTableIter, int part) {
-        TpchTableWorker<Order> orderProducer = new TpchTableWorker<Order>(ringBuffer, nextTableIter,
-            table.getName(), table.getRowStrLen(), part) {
-            @Override
-            protected void appendToBuffer(Order row) {
-
-                this.sqlBuffer.append('(').append(row.getOrderKey())
-                    .append(',').append(row.getCustomerKey())
-                    .append(",\"").append(row.getOrderStatus())
-                    .append("\",");
-
-                appendDecimalWithFrac2(this.sqlBuffer, row.getTotalPriceInCents());
-
-                this.sqlBuffer.append(",\"").append(formatDate(row.getOrderDate()))
-                    .append("\",\"").append(row.getOrderPriority())
-                    .append("\",\"").append(row.getClerk())
-                    .append("\",").append(row.getShipPriority())
-                    .append(",\"").append(row.getComment()).append("\"),");
-            }
-        };
-        return orderProducer;
-    }
-
-    private TpchTableWorker<?> buildPartProducer(TpchTableModel table, Iterator nextTableIter, int part) {
-        TpchTableWorker<Part> partProducer = new TpchTableWorker<Part>(ringBuffer, nextTableIter,
-            table.getName(), table.getRowStrLen(), part) {
-            @Override
-            protected void appendToBuffer(Part row) {
-
-                this.sqlBuffer.append('(').append(row.getPartKey())
-                    .append(",\"").append(row.getName())
-                    .append("\",\"").append(row.getManufacturer())
-                    .append("\",\"").append(row.getBrand())
-                    .append("\",\"").append(row.getType())
-                    .append("\",").append(row.getSize())
-                    .append(",\"").append(row.getContainer())
-                    .append("\",");
-
-                appendDecimalWithFrac2(this.sqlBuffer, row.getRetailPriceInCents());
-
-                this.sqlBuffer.append(",\"").append(row.getComment()).append("\"),");
-            }
-        };
-        return partProducer;
-    }
-
-    private TpchTableWorker<?> buildSupplierProducer(TpchTableModel table, Iterator nextTableIter, int part) {
-        TpchTableWorker<Supplier> supplierProducer = new TpchTableWorker<Supplier>(ringBuffer, nextTableIter,
-            table.getName(), table.getRowStrLen(), part) {
-            @Override
-            protected void appendToBuffer(Supplier row) {
-
-                this.sqlBuffer.append('(').append(row.getSupplierKey())
-                    .append(",\"").append(row.getName())
-                    .append("\",\"").append(row.getAddress())
-                    .append("\",").append(row.getNationKey())
-                    .append(",\"").append(row.getPhone())
-                    .append("\",");
-
-                appendDecimalWithFrac2(this.sqlBuffer, row.getAccountBalanceInCents());
-
-                this.sqlBuffer.append(",\"").append(row.getComment()).append("\"),");
-            }
-        };
-        return supplierProducer;
-    }
-
-    private TpchTableWorker<?> buildPartSuppProducer(TpchTableModel table, Iterator nextTableIter, int part) {
-        TpchTableWorker<PartSupplier> partSuppProducer = new TpchTableWorker<PartSupplier>(ringBuffer, nextTableIter,
-            table.getName(), table.getRowStrLen(), part) {
-            @Override
-            protected void appendToBuffer(PartSupplier row) {
-
-                this.sqlBuffer.append('(').append(row.getPartKey())
-                    .append(',').append(row.getSupplierKey())
-                    .append(',').append(row.getAvailableQuantity())
-                    .append(',');
-
-                appendDecimalWithFrac2(this.sqlBuffer, row.getSupplyCostInCents());
-
-                this.sqlBuffer.append(",\"").append(row.getComment()).append("\"),");
-            }
-        };
-        return partSuppProducer;
-    }
-
-    private TpchTableWorker<?> buildNationProducer(TpchTableModel table, Iterator nextTableIter, int part) {
-        TpchTableWorker<Nation> nationProducer = new TpchTableWorker<Nation>(ringBuffer, nextTableIter,
-            table.getName(), table.getRowStrLen(), part) {
-            @Override
-            protected void appendToBuffer(Nation row) {
-                this.sqlBuffer.append('(').append(row.getNationKey())
-                    .append(",\"").append(row.getName())
-                    .append("\",").append(row.getRegionKey())
-                    .append(",\"").append(row.getComment()).append("\"),");
-            }
-        };
-        return nationProducer;
-    }
-
-    private TpchTableWorker<?> buildRegionWorker(TpchTableModel table, Iterator nextTableIter, int part) {
-        TpchTableWorker<Region> regionProducer = new TpchTableWorker<Region>(ringBuffer, nextTableIter,
-            table.getName(), table.getRowStrLen(), part) {
-            @Override
-            protected void appendToBuffer(Region row) {
-                this.sqlBuffer.append('(').append(row.getRegionKey())
-                    .append(",\"").append(row.getName())
-                    .append("\",\"").append(row.getComment()).append("\"),");
-            }
-        };
-        return regionProducer;
-    }
-
     /**
      * 尽可能同时并发写入不同的表
      */
-    abstract class TpchTableWorker<T> implements Runnable {
+    class TpchTableWorker implements Runnable {
         protected final RingBuffer<BatchInsertSqlEvent> ringBuffer;
         protected final StringBuilder sqlBuffer;
-        protected final Iterator<T> iterator;
+        protected final TableRowGenerator rowGenerator;
         protected final String tableName;
         protected final int estimateRowLen;
         protected final int part;
-        protected final FastDateFormat dateFormat = FastDateFormat.getInstance("yyyy-MM-dd");
         protected int bufferedLineCount = 0;
 
-        TpchTableWorker(RingBuffer<BatchInsertSqlEvent> ringBuffer, Iterator<T> iterator,
+        TpchTableWorker(RingBuffer<BatchInsertSqlEvent> ringBuffer, TableRowGenerator rowGenerator,
                         String tableName, int estimateRowLen) {
-            this(ringBuffer, iterator, tableName, estimateRowLen, 0);
+            this(ringBuffer, rowGenerator, tableName, estimateRowLen, 0);
         }
 
-        TpchTableWorker(RingBuffer<BatchInsertSqlEvent> ringBuffer, Iterator<T> iterator,
+        TpchTableWorker(RingBuffer<BatchInsertSqlEvent> ringBuffer, TableRowGenerator rowGenerator,
                         String tableName, int estimateRowLen, int part) {
             this.ringBuffer = ringBuffer;
-            this.iterator = iterator;
+            this.rowGenerator = rowGenerator;
             this.tableName = tableName;
             this.estimateRowLen = estimateRowLen;
             this.part = part;
@@ -459,9 +257,8 @@ public class TpchProducer implements Producer {
         @Override
         public void run() {
             try {
-                while (iterator.hasNext()) {
-                    T row = iterator.next();
-                    appendToBuffer(row);
+                while (rowGenerator.hasNext()) {
+                    rowGenerator.appendNextRow(sqlBuffer);
                     bufferedLineCount++;
                     if (bufferedLineCount >= EMIT_BATCH_SIZE) {
                         emitLineBuffer();
@@ -477,19 +274,6 @@ public class TpchProducer implements Producer {
                 logger.info("{}-{} produce done", tableName, part);
             }
         }
-
-        /**
-         * TODO 可以自己实现这个逻辑并优化
-         * 返回格式 yyyy-MM-dd
-         *
-         * @param days 自从1970-01-01经过的天数
-         */
-        String formatDate(int days) {
-            Date date = new Date(TimeUnit.DAYS.toMillis(days));
-            return dateFormat.format(date);
-        }
-
-        protected abstract void appendToBuffer(T row);
 
         protected void emitLineBuffer() {
             long sequence = ringBuffer.next();

--- a/batch-tool/src/main/java/worker/tpch/TpchTableModel.java
+++ b/batch-tool/src/main/java/worker/tpch/TpchTableModel.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch;
+
+public enum TpchTableModel {
+    LINEITEM("lineitem", 16, 160),
+    CUSTOMER("customer", 8, 176),
+    ORDERS("orders", 9, 128),
+    PART("part", 9, 128),
+    SUPPLIER("supplier", 7, 128),
+    PART_SUPP("partsupp", 5, 150),
+    NATION("nation", 4, 90),
+    REGION("region", 3, 135);
+
+    private final String name;
+    private final int fieldCount;
+
+    /**
+     * 预计算好的行长度
+     * 包含：分隔符、引号
+     */
+    private final int rowStrLen;
+
+    TpchTableModel(String name, int fieldCount, int rowStrLen) {
+        this.name = name;
+        this.fieldCount = fieldCount;
+        this.rowStrLen = rowStrLen;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getFieldCount() {
+        return fieldCount;
+    }
+
+    public int getRowStrLen() {
+        return rowStrLen;
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/TpchTableModel.java
+++ b/batch-tool/src/main/java/worker/tpch/TpchTableModel.java
@@ -17,6 +17,7 @@
 package worker.tpch;
 
 public enum TpchTableModel {
+
     LINEITEM("lineitem", 16, 160),
     CUSTOMER("customer", 8, 176),
     ORDERS("orders", 9, 128),
@@ -39,6 +40,19 @@ public enum TpchTableModel {
         this.name = name;
         this.fieldCount = fieldCount;
         this.rowStrLen = rowStrLen;
+    }
+
+    public static TpchTableModel parse(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("Empty table name");
+        }
+        name = name.toLowerCase();
+        for (TpchTableModel value : TpchTableModel.values()) {
+            if (value.name.equals(name)) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported table name: " + name);
     }
 
     public String getName() {

--- a/batch-tool/src/main/java/worker/tpch/generator/CustomerGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/CustomerGenerator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.generator;
+
+import io.airlift.tpch.Distributions;
+import io.airlift.tpch.RandomBoundedInt;
+import io.airlift.tpch.RandomString;
+import io.airlift.tpch.RandomText;
+import io.airlift.tpch.TextPool;
+import worker.tpch.util.RandomAlphaNumeric;
+import worker.tpch.util.RandomPhoneNumber;
+
+import static io.airlift.tpch.GenerateUtils.calculateRowCount;
+import static io.airlift.tpch.GenerateUtils.calculateStartIndex;
+import static worker.tpch.util.StringBufferUtil.appendCustomerName;
+import static worker.tpch.util.StringBufferUtil.appendDecimalWithFrac2;
+
+/**
+ * port from io.airlift.tpch
+ */
+public class CustomerGenerator extends TableRowGenerator {
+    public static final int SCALE_BASE = 150_000;
+    private static final int ACCOUNT_BALANCE_MIN = -99999;
+    private static final int ACCOUNT_BALANCE_MAX = 999999;
+    private static final int ADDRESS_AVERAGE_LENGTH = 25;
+    private static final int COMMENT_AVERAGE_LENGTH = 73;
+
+    private final RandomAlphaNumeric addressRandom = new RandomAlphaNumeric(881155353, ADDRESS_AVERAGE_LENGTH);
+    private final RandomBoundedInt nationKeyRandom;
+    private final RandomPhoneNumber phoneRandom = new RandomPhoneNumber(1521138112);
+    private final RandomBoundedInt accountBalanceRandom =
+        new RandomBoundedInt(298370230, ACCOUNT_BALANCE_MIN, ACCOUNT_BALANCE_MAX);
+    private final RandomString marketSegmentRandom;
+    private final RandomText commentRandom;
+
+    public CustomerGenerator(double scaleFactor, int part, int partCount) {
+        this(Distributions.getDefaultDistributions(),
+            TextPool.getDefaultTestPool(),
+            calculateStartIndex(SCALE_BASE, scaleFactor, part, partCount),
+            calculateRowCount(SCALE_BASE, scaleFactor, part, partCount));
+    }
+
+    public CustomerGenerator(Distributions distributions, TextPool textPool, long startIndex, long rowCount) {
+        super(distributions, textPool, startIndex, rowCount);
+
+        nationKeyRandom = new RandomBoundedInt(1489529863, 0, distributions.getNations().size() - 1);
+        marketSegmentRandom = new RandomString(1140279430, distributions.getMarketSegments());
+        commentRandom = new RandomText(1335826707, textPool, COMMENT_AVERAGE_LENGTH);
+
+        addressRandom.advanceRows(startIndex);
+        nationKeyRandom.advanceRows(startIndex);
+        phoneRandom.advanceRows(startIndex);
+        accountBalanceRandom.advanceRows(startIndex);
+        marketSegmentRandom.advanceRows(startIndex);
+        commentRandom.advanceRows(startIndex);
+    }
+
+    @Override
+    public void appendNextRow(StringBuilder sqlBuffer) {
+
+        long nationKey = nationKeyRandom.nextValue();
+        long customerKey = startIndex + index + 1;
+
+        sqlBuffer.append('(').append(customerKey)   // c_custkey
+            .append(",\"");
+
+        appendCustomerName(sqlBuffer, customerKey); // c_name
+
+        sqlBuffer.append("\",\"");
+        addressRandom.appendNextValue(sqlBuffer);   // c_address
+        sqlBuffer.append("\",").append(nationKey).append(",\"");    // c_nationkey
+        phoneRandom.appendNextValue(sqlBuffer, nationKey);  // c_phone
+        sqlBuffer.append("\",");
+
+        appendDecimalWithFrac2(sqlBuffer, accountBalanceRandom.nextValue());    // c_acctbal
+
+        sqlBuffer.append(",\"").append(marketSegmentRandom.nextValue()) // c_mktsegment
+            .append("\",\"").append(commentRandom.nextValue()).append("\"),");  // c_comment
+
+        addressRandom.rowFinished();
+        nationKeyRandom.rowFinished();
+        phoneRandom.rowFinished();
+        accountBalanceRandom.rowFinished();
+        marketSegmentRandom.rowFinished();
+        commentRandom.rowFinished();
+
+        index++;
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/generator/LineItemGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/LineItemGenerator.java
@@ -83,7 +83,6 @@ public class LineItemGenerator extends TableRowGenerator {
 
     private final double scaleFactor;
 
-    private long index;
     private int orderDate;
     private int lineCount;
     private int lineNumber;

--- a/batch-tool/src/main/java/worker/tpch/generator/LineItemGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/LineItemGenerator.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.generator;
+
+import io.airlift.tpch.Distributions;
+import io.airlift.tpch.GenerateUtils;
+import io.airlift.tpch.RandomBoundedInt;
+import io.airlift.tpch.RandomBoundedLong;
+import io.airlift.tpch.RandomString;
+import io.airlift.tpch.RandomText;
+import io.airlift.tpch.TextPool;
+
+import static io.airlift.tpch.GenerateUtils.calculateRowCount;
+import static io.airlift.tpch.GenerateUtils.calculateStartIndex;
+import static io.airlift.tpch.GenerateUtils.toEpochDate;
+import static worker.tpch.generator.OrderGenerator.LINE_COUNT_MAX;
+import static worker.tpch.generator.OrderGenerator.createLineCountRandom;
+import static worker.tpch.generator.OrderGenerator.createOrderDateRandom;
+import static worker.tpch.generator.OrderGenerator.makeOrderKey;
+import static worker.tpch.generator.PartSupplierGenerator.selectPartSupplier;
+import static worker.tpch.util.StringBufferUtil.appendDecimalWithFrac2;
+import static worker.tpch.util.StringBufferUtil.formatDateByDays;
+
+/**
+ * port from io.airlift.tpch
+ */
+public class LineItemGenerator extends TableRowGenerator {
+    private static final int QUANTITY_MIN = 1;
+    private static final int QUANTITY_MAX = 50;
+    private static final int TAX_MIN = 0;
+    private static final int TAX_MAX = 8;
+    private static final int DISCOUNT_MIN = 0;
+    private static final int DISCOUNT_MAX = 10;
+    private static final int PART_KEY_MIN = 1;
+
+    private static final int SHIP_DATE_MIN = 1;
+    private static final int SHIP_DATE_MAX = 121;
+    private static final int COMMIT_DATE_MIN = 30;
+    private static final int COMMIT_DATE_MAX = 90;
+    private static final int RECEIPT_DATE_MIN = 1;
+    private static final int RECEIPT_DATE_MAX = 30;
+
+    static final int ITEM_SHIP_DAYS = SHIP_DATE_MAX + RECEIPT_DATE_MAX;
+
+    private static final int COMMENT_AVERAGE_LENGTH = 27;
+
+    private final RandomBoundedInt orderDateRandom = createOrderDateRandom();
+    private final RandomBoundedInt lineCountRandom = createLineCountRandom();
+
+    private final RandomBoundedInt quantityRandom = createQuantityRandom();
+    private final RandomBoundedInt discountRandom = createDiscountRandom();
+    private final RandomBoundedInt taxRandom = createTaxRandom();
+
+    private final RandomBoundedLong linePartKeyRandom;
+
+    private final RandomBoundedInt supplierNumberRandom = new RandomBoundedInt(2095021727, 0, 3, LINE_COUNT_MAX);
+
+    private final RandomBoundedInt shipDateRandom = createShipDateRandom();
+    private final RandomBoundedInt commitDateRandom =
+        new RandomBoundedInt(904914315, COMMIT_DATE_MIN, COMMIT_DATE_MAX, LINE_COUNT_MAX);
+    private final RandomBoundedInt receiptDateRandom =
+        new RandomBoundedInt(373135028, RECEIPT_DATE_MIN, RECEIPT_DATE_MAX, LINE_COUNT_MAX);
+
+    private final RandomString returnedFlagRandom;
+    private final RandomString shipInstructionsRandom;
+    private final RandomString shipModeRandom;
+
+    private final RandomText commentRandom;
+
+    private final double scaleFactor;
+
+    private long index;
+    private int orderDate;
+    private int lineCount;
+    private int lineNumber;
+
+    public LineItemGenerator(double scaleFactor, int part, int partCount) {
+        this(Distributions.getDefaultDistributions(),
+            TextPool.getDefaultTestPool(),
+            scaleFactor,
+            calculateStartIndex(OrderGenerator.SCALE_BASE, scaleFactor, part, partCount),
+            calculateRowCount(OrderGenerator.SCALE_BASE, scaleFactor, part, partCount));
+    }
+
+    public LineItemGenerator(Distributions distributions, TextPool textPool,
+                             double scaleFactor,
+                             long startIndex, long rowCount) {
+        super(distributions, textPool, startIndex, rowCount);
+        this.scaleFactor = scaleFactor;
+
+        returnedFlagRandom = new RandomString(717419739, distributions.getReturnFlags(), LINE_COUNT_MAX);
+        shipInstructionsRandom = new RandomString(1371272478, distributions.getShipInstructions(), LINE_COUNT_MAX);
+        shipModeRandom = new RandomString(675466456, distributions.getShipModes(), LINE_COUNT_MAX);
+        commentRandom = new RandomText(1095462486, textPool, COMMENT_AVERAGE_LENGTH, LINE_COUNT_MAX);
+
+        linePartKeyRandom = createPartKeyRandom(scaleFactor);
+
+        orderDateRandom.advanceRows(startIndex);
+        lineCountRandom.advanceRows(startIndex);
+
+        quantityRandom.advanceRows(startIndex);
+        discountRandom.advanceRows(startIndex);
+        taxRandom.advanceRows(startIndex);
+
+        linePartKeyRandom.advanceRows(startIndex);
+
+        supplierNumberRandom.advanceRows(startIndex);
+
+        shipDateRandom.advanceRows(startIndex);
+        commitDateRandom.advanceRows(startIndex);
+        receiptDateRandom.advanceRows(startIndex);
+
+        returnedFlagRandom.advanceRows(startIndex);
+        shipInstructionsRandom.advanceRows(startIndex);
+        shipModeRandom.advanceRows(startIndex);
+
+        commentRandom.advanceRows(startIndex);
+
+        // generate information for initial order
+        orderDate = orderDateRandom.nextValue();
+        lineCount = lineCountRandom.nextValue() - 1;
+    }
+
+    static RandomBoundedInt createQuantityRandom() {
+        return new RandomBoundedInt(209208115, QUANTITY_MIN, QUANTITY_MAX, LINE_COUNT_MAX);
+    }
+
+    static RandomBoundedInt createDiscountRandom() {
+        return new RandomBoundedInt(554590007, DISCOUNT_MIN, DISCOUNT_MAX, LINE_COUNT_MAX);
+    }
+
+    static RandomBoundedInt createTaxRandom() {
+        return new RandomBoundedInt(721958466, TAX_MIN, TAX_MAX, LINE_COUNT_MAX);
+    }
+
+    static RandomBoundedLong createPartKeyRandom(double scaleFactor) {
+        return new RandomBoundedLong(1808217256, scaleFactor >= 30000, PART_KEY_MIN,
+            (long) (PartGenerator.SCALE_BASE * scaleFactor), LINE_COUNT_MAX);
+    }
+
+    static RandomBoundedInt createShipDateRandom() {
+        return new RandomBoundedInt(1769349045, SHIP_DATE_MIN, SHIP_DATE_MAX, LINE_COUNT_MAX);
+    }
+
+    @Override
+    public void appendNextRow(StringBuilder sqlBuffer) {
+        long orderKey = makeOrderKey(startIndex + index + 1);
+        int quantity = quantityRandom.nextValue();
+        int discount = discountRandom.nextValue();
+        int tax = taxRandom.nextValue();
+
+        long partKey = linePartKeyRandom.nextValue();
+
+        int supplierNumber = supplierNumberRandom.nextValue();
+        long supplierKey = selectPartSupplier(partKey, supplierNumber, scaleFactor);
+
+        long partPrice = PartGenerator.calculatePartPrice(partKey);
+        long extendedPrice = partPrice * quantity;
+
+        int shipDate = shipDateRandom.nextValue();
+        shipDate += orderDate;
+        int commitDate = commitDateRandom.nextValue();
+        commitDate += orderDate;
+        int receiptDate = receiptDateRandom.nextValue();
+        receiptDate += shipDate;
+
+        shipDate = toEpochDate(shipDate);
+        commitDate = toEpochDate(commitDate);
+        receiptDate = toEpochDate(receiptDate);
+
+        String returnedFlag;
+        if (GenerateUtils.isInPast(receiptDate)) {
+            returnedFlag = returnedFlagRandom.nextValue();
+        } else {
+            returnedFlag = "N";
+        }
+
+        String status;
+        if (GenerateUtils.isInPast(shipDate)) {
+            status = "F";
+        } else {
+            status = "O";
+        }
+
+        String shipInstructions = shipInstructionsRandom.nextValue();
+        String shipMode = shipModeRandom.nextValue();
+        String comment = commentRandom.nextValue();
+
+        sqlBuffer.append('(').append(orderKey)
+            .append(',').append(partKey)
+            .append(',').append(supplierKey)
+            .append(',').append(lineNumber + 1)
+            .append(',').append(quantity)
+            .append(",");
+
+        appendDecimalWithFrac2(sqlBuffer, extendedPrice);
+        sqlBuffer.append(',');
+        appendDecimalWithFrac2(sqlBuffer, discount);
+        sqlBuffer.append(',');
+        appendDecimalWithFrac2(sqlBuffer, tax);
+
+        sqlBuffer.append(",\"").append(returnedFlag)
+            .append("\",\"").append(status)
+            .append("\",\"");
+
+        formatDateByDays(sqlBuffer, shipDate);
+        sqlBuffer.append("\",\"");
+        formatDateByDays(sqlBuffer, commitDate);
+        sqlBuffer.append("\",\"");
+        formatDateByDays(sqlBuffer, receiptDate);
+        sqlBuffer.append("\",\"").append(shipInstructions)
+            .append("\",\"").append(shipMode)
+            .append("\",\"").append(comment).append("\"),");
+
+        lineNumber++;
+
+        // advance next row only when all lines for the order have been produced
+        if (lineNumber > lineCount) {
+            orderDateRandom.rowFinished();
+
+            lineCountRandom.rowFinished();
+            quantityRandom.rowFinished();
+            discountRandom.rowFinished();
+            taxRandom.rowFinished();
+
+            linePartKeyRandom.rowFinished();
+
+            supplierNumberRandom.rowFinished();
+
+            shipDateRandom.rowFinished();
+            commitDateRandom.rowFinished();
+            receiptDateRandom.rowFinished();
+
+            returnedFlagRandom.rowFinished();
+            shipInstructionsRandom.rowFinished();
+            shipModeRandom.rowFinished();
+
+            commentRandom.rowFinished();
+
+            index++;
+
+            // generate information for next order
+            lineCount = lineCountRandom.nextValue() - 1;
+            orderDate = orderDateRandom.nextValue();
+            lineNumber = 0;
+        }
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/generator/NationGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/NationGenerator.java
@@ -29,7 +29,6 @@ public class NationGenerator extends TableRowGenerator {
 
     private final Distribution nations;
     private final RandomText commentRandom;
-    private int index;
 
     public NationGenerator() {
         this(Distributions.getDefaultDistributions(),
@@ -45,8 +44,8 @@ public class NationGenerator extends TableRowGenerator {
     @Override
     public void appendNextRow(StringBuilder sqlBuffer) {
         sqlBuffer.append('(').append(index)
-            .append(",\"").append(nations.getValue(index))
-            .append("\",").append(nations.getWeight(index))
+            .append(",\"").append(nations.getValue((int) index))
+            .append("\",").append(nations.getWeight((int) index))
             .append(",\"").append(commentRandom.nextValue()).append("\"),");
 
         commentRandom.rowFinished();

--- a/batch-tool/src/main/java/worker/tpch/generator/NationGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/NationGenerator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.generator;
+
+import io.airlift.tpch.Distribution;
+import io.airlift.tpch.Distributions;
+import io.airlift.tpch.RandomText;
+import io.airlift.tpch.TextPool;
+
+/**
+ * port from io.airlift.tpch
+ */
+public class NationGenerator extends TableRowGenerator {
+    private static final int COMMENT_AVERAGE_LENGTH = 72;
+
+    private final Distribution nations;
+    private final RandomText commentRandom;
+    private int index;
+
+    public NationGenerator() {
+        this(Distributions.getDefaultDistributions(),
+            TextPool.getDefaultTestPool());
+    }
+
+    public NationGenerator(Distributions distributions, TextPool textPool) {
+        super(distributions, textPool, 0, distributions.getNations().size());
+        this.nations = distributions.getNations();
+        this.commentRandom = new RandomText(606179079, textPool, COMMENT_AVERAGE_LENGTH);
+    }
+
+    @Override
+    public void appendNextRow(StringBuilder sqlBuffer) {
+        sqlBuffer.append('(').append(index)
+            .append(",\"").append(nations.getValue(index))
+            .append("\",").append(nations.getWeight(index))
+            .append(",\"").append(commentRandom.nextValue()).append("\"),");
+
+        commentRandom.rowFinished();
+        index++;
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/generator/OrderGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/OrderGenerator.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package worker.tpch.generator;
+
+import io.airlift.tpch.CustomerGenerator;
+import io.airlift.tpch.Distributions;
+import io.airlift.tpch.GenerateUtils;
+import io.airlift.tpch.RandomBoundedInt;
+import io.airlift.tpch.RandomBoundedLong;
+import io.airlift.tpch.RandomString;
+import io.airlift.tpch.RandomText;
+import io.airlift.tpch.TextPool;
+
+import static io.airlift.tpch.GenerateUtils.MIN_GENERATE_DATE;
+import static io.airlift.tpch.GenerateUtils.TOTAL_DATE_RANGE;
+import static io.airlift.tpch.GenerateUtils.calculateRowCount;
+import static io.airlift.tpch.GenerateUtils.calculateStartIndex;
+import static worker.tpch.generator.LineItemGenerator.ITEM_SHIP_DAYS;
+import static worker.tpch.generator.LineItemGenerator.createDiscountRandom;
+import static worker.tpch.generator.LineItemGenerator.createPartKeyRandom;
+import static worker.tpch.generator.LineItemGenerator.createQuantityRandom;
+import static worker.tpch.generator.LineItemGenerator.createShipDateRandom;
+import static worker.tpch.generator.LineItemGenerator.createTaxRandom;
+import static worker.tpch.generator.PartGenerator.calculatePartPrice;
+import static worker.tpch.util.StringBufferUtil.appendClerk;
+import static worker.tpch.util.StringBufferUtil.appendDecimalWithFrac2;
+import static worker.tpch.util.StringBufferUtil.formatDateByDays;
+
+/**
+ * port from io.airlift.tpch
+ */
+public class OrderGenerator extends TableRowGenerator {
+    public static final int SCALE_BASE = 1_500_000;
+
+    // portion with have no orders
+    public static final int CUSTOMER_MORTALITY = 3;
+    static final int LINE_COUNT_MAX = 7;
+    private static final int ORDER_DATE_MIN = MIN_GENERATE_DATE;
+    private static final int ORDER_DATE_MAX = ORDER_DATE_MIN + (TOTAL_DATE_RANGE - ITEM_SHIP_DAYS - 1);
+    private static final int CLERK_SCALE_BASE = 1000;
+    private static final int LINE_COUNT_MIN = 1;
+    private static final int COMMENT_AVERAGE_LENGTH = 49;
+
+    private static final int ORDER_KEY_SPARSE_BITS = 2;
+    private static final int ORDER_KEY_SPARSE_KEEP = 3;
+
+    private final RandomBoundedInt orderDateRandom = createOrderDateRandom();
+    private final RandomBoundedInt lineCountRandom = createLineCountRandom();
+    private final RandomBoundedLong customerKeyRandom;
+    private final RandomString orderPriorityRandom;
+    private final RandomBoundedInt clerkRandom;
+    private final RandomText commentRandom;
+
+    private final RandomBoundedInt lineQuantityRandom = createQuantityRandom();
+    private final RandomBoundedInt lineDiscountRandom = createDiscountRandom();
+    private final RandomBoundedInt lineTaxRandom = createTaxRandom();
+    private final RandomBoundedLong linePartKeyRandom;
+    private final RandomBoundedInt lineShipDateRandom = createShipDateRandom();
+
+    private final long maxCustomerKey;
+
+    public OrderGenerator(double scaleFactor, int part, int partCount) {
+        this(Distributions.getDefaultDistributions(),
+            TextPool.getDefaultTestPool(),
+            scaleFactor,
+            calculateStartIndex(SCALE_BASE, scaleFactor, part, partCount),
+            calculateRowCount(SCALE_BASE, scaleFactor, part, partCount));
+    }
+
+    public OrderGenerator(Distributions distributions, TextPool textPool,
+                          double scaleFactor, long startIndex, long rowCount) {
+        super(distributions, textPool, startIndex, rowCount);
+
+        clerkRandom =
+            new RandomBoundedInt(1171034773, 1, Math.max((int) (scaleFactor * CLERK_SCALE_BASE), CLERK_SCALE_BASE));
+
+        maxCustomerKey = (long) (CustomerGenerator.SCALE_BASE * scaleFactor);
+        customerKeyRandom = new RandomBoundedLong(851767375, scaleFactor >= 30000, 1, maxCustomerKey);
+
+        orderPriorityRandom = new RandomString(591449447, distributions.getOrderPriorities());
+        commentRandom = new RandomText(276090261, textPool, COMMENT_AVERAGE_LENGTH);
+
+        linePartKeyRandom = createPartKeyRandom(scaleFactor);
+
+        orderDateRandom.advanceRows(startIndex);
+        lineCountRandom.advanceRows(startIndex);
+        customerKeyRandom.advanceRows(startIndex);
+        orderPriorityRandom.advanceRows(startIndex);
+        clerkRandom.advanceRows(startIndex);
+        commentRandom.advanceRows(startIndex);
+
+        lineQuantityRandom.advanceRows(startIndex);
+        lineDiscountRandom.advanceRows(startIndex);
+        lineShipDateRandom.advanceRows(startIndex);
+        lineTaxRandom.advanceRows(startIndex);
+        linePartKeyRandom.advanceRows(startIndex);
+    }
+
+    static RandomBoundedInt createLineCountRandom() {
+        return new RandomBoundedInt(1434868289, LINE_COUNT_MIN, LINE_COUNT_MAX);
+    }
+
+    static RandomBoundedInt createOrderDateRandom() {
+        return new RandomBoundedInt(1066728069, ORDER_DATE_MIN, ORDER_DATE_MAX);
+    }
+
+    static long makeOrderKey(long orderIndex) {
+        long lowBits = orderIndex & ((1 << ORDER_KEY_SPARSE_KEEP) - 1);
+
+        long key = orderIndex;
+        key >>= ORDER_KEY_SPARSE_KEEP;
+        key <<= ORDER_KEY_SPARSE_BITS;
+        key <<= ORDER_KEY_SPARSE_KEEP;
+        key += lowBits;
+
+        return key;
+    }
+
+    @Override
+    public void appendNextRow(StringBuilder sqlBuffer) {
+        long orderKey = makeOrderKey(startIndex + index + 1);
+        int orderDate = orderDateRandom.nextValue();
+
+        // generate customer key, taking into account customer mortality rate
+        long customerKey = customerKeyRandom.nextValue();
+        int delta = 1;
+        while (customerKey % CUSTOMER_MORTALITY == 0) {
+            customerKey += delta;
+            customerKey = Math.min(customerKey, maxCustomerKey);
+            delta *= -1;
+        }
+
+        long totalPrice = 0;
+        int shippedCount = 0;
+
+        int lineCount = lineCountRandom.nextValue();
+        for (long lineNumber = 0; lineNumber < lineCount; lineNumber++) {
+            int quantity = lineQuantityRandom.nextValue();
+            int discount = lineDiscountRandom.nextValue();
+            int tax = lineTaxRandom.nextValue();
+
+            long partKey = linePartKeyRandom.nextValue();
+
+            long partPrice = calculatePartPrice(partKey);
+            long extendedPrice = partPrice * quantity;
+            long discountedPrice = extendedPrice * (100 - discount);
+            totalPrice += ((discountedPrice / 100) * (100 + tax)) / 100;
+
+            int shipDate = lineShipDateRandom.nextValue();
+            shipDate += orderDate;
+            if (GenerateUtils.isInPast(shipDate)) {
+                shippedCount++;
+            }
+        }
+
+        char orderStatus;
+        if (shippedCount == lineCount) {
+            orderStatus = 'F';
+        } else if (shippedCount > 0) {
+            orderStatus = 'P';
+        } else {
+            orderStatus = 'O';
+        }
+
+        sqlBuffer.append('(').append(orderKey)
+            .append(',').append(customerKey)
+            .append(",\"").append(orderStatus)
+            .append("\",");
+
+        appendDecimalWithFrac2(sqlBuffer, totalPrice);
+
+        sqlBuffer.append(",\"");
+        formatDateByDays(sqlBuffer, orderDate);
+
+        sqlBuffer.append("\",\"").append(orderPriorityRandom.nextValue());
+        appendClerk(sqlBuffer, clerkRandom.nextValue());
+        sqlBuffer.append("\",").append(0)
+            .append(",\"").append(commentRandom.nextValue()).append("\"),");
+
+        orderDateRandom.rowFinished();
+        lineCountRandom.rowFinished();
+        customerKeyRandom.rowFinished();
+        orderPriorityRandom.rowFinished();
+        clerkRandom.rowFinished();
+        commentRandom.rowFinished();
+
+        lineQuantityRandom.rowFinished();
+        lineDiscountRandom.rowFinished();
+        lineShipDateRandom.rowFinished();
+        lineTaxRandom.rowFinished();
+        linePartKeyRandom.rowFinished();
+
+        index++;
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/generator/OrderGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/OrderGenerator.java
@@ -185,7 +185,7 @@ public class OrderGenerator extends TableRowGenerator {
         sqlBuffer.append(",\"");
         formatDateByDays(sqlBuffer, orderDate);
 
-        sqlBuffer.append("\",\"").append(orderPriorityRandom.nextValue());
+        sqlBuffer.append("\",\"").append(orderPriorityRandom.nextValue()).append("\",\"");
         appendClerk(sqlBuffer, clerkRandom.nextValue());
         sqlBuffer.append("\",").append(0)
             .append(",\"").append(commentRandom.nextValue()).append("\"),");

--- a/batch-tool/src/main/java/worker/tpch/generator/PartGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/PartGenerator.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.generator;
+
+import io.airlift.tpch.Distributions;
+import io.airlift.tpch.RandomBoundedInt;
+import io.airlift.tpch.RandomString;
+import io.airlift.tpch.RandomStringSequence;
+import io.airlift.tpch.RandomText;
+import io.airlift.tpch.TextPool;
+
+import static io.airlift.tpch.GenerateUtils.calculateRowCount;
+import static io.airlift.tpch.GenerateUtils.calculateStartIndex;
+import static worker.tpch.util.StringBufferUtil.appendDecimalWithFrac2;
+
+/**
+ * port from io.airlift.tpch
+ */
+public class PartGenerator extends TableRowGenerator {
+    public static final int SCALE_BASE = 200_000;
+
+    private static final int NAME_WORDS = 5;
+    private static final int MANUFACTURER_MIN = 1;
+    private static final int MANUFACTURER_MAX = 5;
+    private static final int BRAND_MIN = 1;
+    private static final int BRAND_MAX = 5;
+    private static final int SIZE_MIN = 1;
+    private static final int SIZE_MAX = 50;
+    private static final int COMMENT_AVERAGE_LENGTH = 14;
+
+    private final RandomStringSequence nameRandom;
+    private final RandomBoundedInt manufacturerRandom;
+    private final RandomBoundedInt brandRandom;
+    private final RandomString typeRandom;
+    private final RandomBoundedInt sizeRandom;
+    private final RandomString containerRandom;
+    private final RandomText commentRandom;
+
+    public PartGenerator(double scaleFactor, int part, int partCount) {
+        this(Distributions.getDefaultDistributions(), TextPool.getDefaultTestPool(),
+            calculateStartIndex(SCALE_BASE, scaleFactor, part, partCount),
+            calculateRowCount(SCALE_BASE, scaleFactor, part, partCount));
+    }
+
+    public PartGenerator(Distributions distributions, TextPool textPool, long startIndex, long rowCount) {
+        super(distributions, textPool, startIndex, rowCount);
+
+        nameRandom = new RandomStringSequence(709314158, NAME_WORDS, distributions.getPartColors());
+        manufacturerRandom = new RandomBoundedInt(1, MANUFACTURER_MIN, MANUFACTURER_MAX);
+        brandRandom = new RandomBoundedInt(46831694, BRAND_MIN, BRAND_MAX);
+        typeRandom = new RandomString(1841581359, distributions.getPartTypes());
+        sizeRandom = new RandomBoundedInt(1193163244, SIZE_MIN, SIZE_MAX);
+        containerRandom = new RandomString(727633698, distributions.getPartContainers());
+        commentRandom = new RandomText(804159733, textPool, COMMENT_AVERAGE_LENGTH);
+
+        nameRandom.advanceRows(startIndex);
+        manufacturerRandom.advanceRows(startIndex);
+        brandRandom.advanceRows(startIndex);
+        typeRandom.advanceRows(startIndex);
+        sizeRandom.advanceRows(startIndex);
+        containerRandom.advanceRows(startIndex);
+        commentRandom.advanceRows(startIndex);
+    }
+
+    @Override
+    public void appendNextRow(StringBuilder sqlBuffer) {
+        long partKey = startIndex + index + 1;
+
+        int manufacturer = manufacturerRandom.nextValue();
+        int brand = manufacturer * 10 + brandRandom.nextValue();
+
+        sqlBuffer.append('(').append(partKey)
+            .append(",\"").append(nameRandom.nextValue())
+            .append("\",\"Manufacturer#").append(manufacturer)
+            .append("\",\"Brand").append(brand)
+            .append("\",\"").append(typeRandom.nextValue())
+            .append("\",").append(sizeRandom.nextValue())
+            .append(",\"").append(containerRandom.nextValue())
+            .append("\",");
+
+        appendDecimalWithFrac2(sqlBuffer, calculatePartPrice(partKey));
+
+        sqlBuffer.append(",\"").append(commentRandom.nextValue()).append("\"),");
+
+        nameRandom.rowFinished();
+        manufacturerRandom.rowFinished();
+        brandRandom.rowFinished();
+        typeRandom.rowFinished();
+        sizeRandom.rowFinished();
+        containerRandom.rowFinished();
+        commentRandom.rowFinished();
+
+        index++;
+    }
+
+    static long calculatePartPrice(long p) {
+        long price = 90000;
+
+        // limit contribution to $200
+        price += (p / 10) % 20001;
+        price += (p % 1000) * 100;
+
+        return (price);
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/generator/PartSupplierGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/PartSupplierGenerator.java
@@ -43,7 +43,6 @@ public class PartSupplierGenerator extends TableRowGenerator {
     private final RandomBoundedInt supplyCostRandom;
     private final RandomText commentRandom;
 
-    private long index;
     private int partSupplierNumber;
 
     public PartSupplierGenerator(double scaleFactor, int part, int partCount) {

--- a/batch-tool/src/main/java/worker/tpch/generator/PartSupplierGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/PartSupplierGenerator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.generator;
+
+import io.airlift.tpch.RandomBoundedInt;
+import io.airlift.tpch.RandomText;
+import io.airlift.tpch.TextPool;
+
+import static io.airlift.tpch.GenerateUtils.calculateRowCount;
+import static io.airlift.tpch.GenerateUtils.calculateStartIndex;
+import static worker.tpch.util.StringBufferUtil.appendDecimalWithFrac2;
+
+/**
+ * port from io.airlift.tpch
+ */
+public class PartSupplierGenerator extends TableRowGenerator {
+    private static final int SUPPLIERS_PER_PART = 4;
+
+    private static final int AVAILABLE_QUANTITY_MIN = 1;
+    private static final int AVAILABLE_QUANTITY_MAX = 9999;
+
+    private static final int SUPPLY_COST_MIN = 100;
+    private static final int SUPPLY_COST_MAX = 100000;
+
+    private static final int COMMENT_AVERAGE_LENGTH = 124;
+
+    private final double scaleFactor;
+
+    public PartSupplierGenerator(double scaleFactor, int part, int partCount) {
+        this(TextPool.getDefaultTestPool(),
+            scaleFactor,
+            calculateStartIndex(PartGenerator.SCALE_BASE, scaleFactor, part, partCount),
+            calculateRowCount(PartGenerator.SCALE_BASE, scaleFactor, part, partCount));
+    }
+
+    static long selectPartSupplier(long partKey, long supplierNumber, double scaleFactor) {
+        long supplierCount = (long) (SupplierGenerator.SCALE_BASE * scaleFactor);
+        return ((partKey + (supplierNumber * ((supplierCount / SUPPLIERS_PER_PART) + ((partKey - 1) / supplierCount))))
+            % supplierCount) + 1;
+    }
+
+    private final RandomBoundedInt availableQuantityRandom;
+    private final RandomBoundedInt supplyCostRandom;
+    private final RandomText commentRandom;
+
+    private long index;
+    private int partSupplierNumber;
+
+    public PartSupplierGenerator(TextPool textPool, double scaleFactor, long startIndex, long rowCount) {
+        super(null, textPool, startIndex, rowCount);
+        this.scaleFactor = scaleFactor;
+
+        availableQuantityRandom =
+            new RandomBoundedInt(1671059989, AVAILABLE_QUANTITY_MIN, AVAILABLE_QUANTITY_MAX, SUPPLIERS_PER_PART);
+        supplyCostRandom = new RandomBoundedInt(1051288424, SUPPLY_COST_MIN, SUPPLY_COST_MAX, SUPPLIERS_PER_PART);
+        commentRandom = new RandomText(1961692154, textPool, COMMENT_AVERAGE_LENGTH, SUPPLIERS_PER_PART);
+
+        availableQuantityRandom.advanceRows(startIndex);
+        supplyCostRandom.advanceRows(startIndex);
+        commentRandom.advanceRows(startIndex);
+    }
+
+    @Override
+    public void appendNextRow(StringBuilder sqlBuffer) {
+        long partKey = startIndex + index + 1;
+
+        sqlBuffer.append('(').append(partKey)
+            .append(',').append(selectPartSupplier(partKey, partSupplierNumber, scaleFactor))
+            .append(',').append(availableQuantityRandom.nextValue())
+            .append(',');
+
+        appendDecimalWithFrac2(sqlBuffer, supplyCostRandom.nextValue());
+
+        sqlBuffer.append(",\"").append(commentRandom.nextValue()).append("\"),");
+
+        partSupplierNumber++;
+
+        // advance next row only when all lines for the order have been produced
+        if (partSupplierNumber >= SUPPLIERS_PER_PART) {
+            availableQuantityRandom.rowFinished();
+            supplyCostRandom.rowFinished();
+            commentRandom.rowFinished();
+
+            index++;
+            partSupplierNumber = 0;
+        }
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/generator/PartSupplierGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/PartSupplierGenerator.java
@@ -29,7 +29,6 @@ import static worker.tpch.util.StringBufferUtil.appendDecimalWithFrac2;
  */
 public class PartSupplierGenerator extends TableRowGenerator {
     private static final int SUPPLIERS_PER_PART = 4;
-
     private static final int AVAILABLE_QUANTITY_MIN = 1;
     private static final int AVAILABLE_QUANTITY_MAX = 9999;
 
@@ -40,25 +39,19 @@ public class PartSupplierGenerator extends TableRowGenerator {
 
     private final double scaleFactor;
 
-    public PartSupplierGenerator(double scaleFactor, int part, int partCount) {
-        this(TextPool.getDefaultTestPool(),
-            scaleFactor,
-            calculateStartIndex(PartGenerator.SCALE_BASE, scaleFactor, part, partCount),
-            calculateRowCount(PartGenerator.SCALE_BASE, scaleFactor, part, partCount));
-    }
-
-    static long selectPartSupplier(long partKey, long supplierNumber, double scaleFactor) {
-        long supplierCount = (long) (SupplierGenerator.SCALE_BASE * scaleFactor);
-        return ((partKey + (supplierNumber * ((supplierCount / SUPPLIERS_PER_PART) + ((partKey - 1) / supplierCount))))
-            % supplierCount) + 1;
-    }
-
     private final RandomBoundedInt availableQuantityRandom;
     private final RandomBoundedInt supplyCostRandom;
     private final RandomText commentRandom;
 
     private long index;
     private int partSupplierNumber;
+
+    public PartSupplierGenerator(double scaleFactor, int part, int partCount) {
+        this(TextPool.getDefaultTestPool(),
+            scaleFactor,
+            calculateStartIndex(PartGenerator.SCALE_BASE, scaleFactor, part, partCount),
+            calculateRowCount(PartGenerator.SCALE_BASE, scaleFactor, part, partCount));
+    }
 
     public PartSupplierGenerator(TextPool textPool, double scaleFactor, long startIndex, long rowCount) {
         super(null, textPool, startIndex, rowCount);
@@ -99,4 +92,11 @@ public class PartSupplierGenerator extends TableRowGenerator {
             partSupplierNumber = 0;
         }
     }
+
+    static long selectPartSupplier(long partKey, long supplierNumber, double scaleFactor) {
+        long supplierCount = (long) (SupplierGenerator.SCALE_BASE * scaleFactor);
+        return ((partKey + (supplierNumber * ((supplierCount / SUPPLIERS_PER_PART) + ((partKey - 1) / supplierCount))))
+            % supplierCount) + 1;
+    }
+
 }

--- a/batch-tool/src/main/java/worker/tpch/generator/RegionGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/RegionGenerator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.generator;
+
+import io.airlift.tpch.Distribution;
+import io.airlift.tpch.Distributions;
+import io.airlift.tpch.RandomText;
+import io.airlift.tpch.TextPool;
+
+/**
+ * port from io.airlift.tpch
+ */
+public class RegionGenerator extends TableRowGenerator {
+    private static final int COMMENT_AVERAGE_LENGTH = 72;
+
+    private final Distribution regions;
+    private final RandomText commentRandom;
+
+    public RegionGenerator() {
+        this(Distributions.getDefaultDistributions(),
+            TextPool.getDefaultTestPool());
+    }
+
+    public RegionGenerator(Distributions distributions, TextPool textPool) {
+        super(distributions, textPool, 0, distributions.getRegions().size());
+
+        this.regions = distributions.getRegions();
+        this.commentRandom = new RandomText(1500869201, textPool, COMMENT_AVERAGE_LENGTH);
+    }
+
+    @Override
+    public void appendNextRow(StringBuilder sqlBuffer) {
+        sqlBuffer.append('(').append(index)
+            .append(",\"").append(regions.getValue((int) index))
+            .append("\",\"").append(commentRandom.nextValue()).append("\"),");
+
+        commentRandom.rowFinished();
+        index++;
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/generator/SupplierGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/SupplierGenerator.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.generator;
+
+import io.airlift.tpch.Distributions;
+import io.airlift.tpch.RandomAlphaNumeric;
+import io.airlift.tpch.RandomBoundedInt;
+import io.airlift.tpch.RandomInt;
+import io.airlift.tpch.RandomText;
+import io.airlift.tpch.TextPool;
+import worker.tpch.util.RandomPhoneNumber;
+
+import static io.airlift.tpch.GenerateUtils.calculateRowCount;
+import static io.airlift.tpch.GenerateUtils.calculateStartIndex;
+import static worker.tpch.util.StringBufferUtil.appendDecimalWithFrac2;
+import static worker.tpch.util.StringBufferUtil.appendSupplier;
+
+/**
+ * port from io.airlift.tpch
+ */
+public class SupplierGenerator extends TableRowGenerator {
+    public static final int SCALE_BASE = 10_000;
+    public static final String BBB_BASE_TEXT = "Customer ";
+    public static final String BBB_COMPLAINT_TEXT = "Complaints";
+    public static final String BBB_RECOMMEND_TEXT = "Recommends";
+    public static final int BBB_COMMENT_LENGTH = BBB_BASE_TEXT.length() + BBB_COMPLAINT_TEXT.length();
+    public static final int BBB_COMMENTS_PER_SCALE_BASE = 10;
+    public static final int BBB_COMPLAINT_PERCENT = 50;
+    private static final int ACCOUNT_BALANCE_MIN = -99999;
+    private static final int ACCOUNT_BALANCE_MAX = 999999;
+    private static final int ADDRESS_AVERAGE_LENGTH = 25;
+    private static final int COMMENT_AVERAGE_LENGTH = 63;
+
+    private final RandomAlphaNumeric addressRandom = new RandomAlphaNumeric(706178559, ADDRESS_AVERAGE_LENGTH);
+    private final RandomBoundedInt nationKeyRandom;
+    private final RandomPhoneNumber phoneRandom = new RandomPhoneNumber(884434366);
+    private final RandomBoundedInt accountBalanceRandom =
+        new RandomBoundedInt(962338209, ACCOUNT_BALANCE_MIN, ACCOUNT_BALANCE_MAX);
+    private final RandomText commentRandom;
+    private final RandomBoundedInt bbbCommentRandom = new RandomBoundedInt(202794285, 1, SCALE_BASE);
+    private final RandomInt bbbJunkRandom = new RandomInt(263032577, 1);
+    private final RandomInt bbbOffsetRandom = new RandomInt(715851524, 1);
+    private final RandomBoundedInt bbbTypeRandom = new RandomBoundedInt(753643799, 0, 100);
+
+    public SupplierGenerator(double scaleFactor, int part, int partCount) {
+        this(Distributions.getDefaultDistributions(), TextPool.getDefaultTestPool(),
+            calculateStartIndex(SCALE_BASE, scaleFactor, part, partCount),
+            calculateRowCount(SCALE_BASE, scaleFactor, part, partCount));
+    }
+
+    private SupplierGenerator(Distributions distributions, TextPool textPool, long startIndex, long rowCount) {
+        super(distributions, textPool, startIndex, rowCount);
+
+        nationKeyRandom = new RandomBoundedInt(110356601, 0, distributions.getNations().size() - 1);
+        commentRandom = new RandomText(1341315363, textPool, COMMENT_AVERAGE_LENGTH);
+
+        addressRandom.advanceRows(startIndex);
+        nationKeyRandom.advanceRows(startIndex);
+        phoneRandom.advanceRows(startIndex);
+        accountBalanceRandom.advanceRows(startIndex);
+        commentRandom.advanceRows(startIndex);
+        bbbCommentRandom.advanceRows(startIndex);
+        bbbJunkRandom.advanceRows(startIndex);
+        bbbOffsetRandom.advanceRows(startIndex);
+        bbbTypeRandom.advanceRows(startIndex);
+    }
+
+    @Override
+    public void appendNextRow(StringBuilder sqlBuffer) {
+        long supplierKey = startIndex + index + 1;
+
+        String comment = commentRandom.nextValue();
+        StringBuilder commentBuffer = null;
+        // Add supplier complaints or commendation to the comment
+        int bbbCommentRandomValue = bbbCommentRandom.nextValue();
+        if (bbbCommentRandomValue <= BBB_COMMENTS_PER_SCALE_BASE) {
+            commentBuffer = new StringBuilder(comment);
+
+            // select random place for BBB comment
+            int noise = bbbJunkRandom.nextInt(0, (comment.length() - BBB_COMMENT_LENGTH));
+            int offset = bbbOffsetRandom.nextInt(0, (comment.length() - (BBB_COMMENT_LENGTH + noise)));
+
+            // select complaint or recommendation
+            String type;
+            if (bbbTypeRandom.nextValue() < BBB_COMPLAINT_PERCENT) {
+                type = BBB_COMPLAINT_TEXT;
+            } else {
+                type = BBB_RECOMMEND_TEXT;
+            }
+
+            // write base text (e.g., "Customer ")
+            commentBuffer.replace(offset, offset + BBB_BASE_TEXT.length(), BBB_BASE_TEXT);
+
+            // write complaint or commendation text (e.g., "Complaints" or "Recommends")
+            commentBuffer.replace(
+                BBB_BASE_TEXT.length() + offset + noise,
+                BBB_BASE_TEXT.length() + offset + noise + type.length(),
+                type);
+        }
+
+        long nationKey = nationKeyRandom.nextValue();
+
+        sqlBuffer.append('(').append(supplierKey).append(",\"");
+
+        appendSupplier(sqlBuffer, supplierKey);
+        sqlBuffer.append("\",\"").append(addressRandom.nextValue())
+            .append("\",").append(nationKey)
+            .append(",\"");
+
+        phoneRandom.appendNextValue(sqlBuffer, nationKey);
+        sqlBuffer.append("\",");
+
+        appendDecimalWithFrac2(sqlBuffer, accountBalanceRandom.nextValue());
+
+        if (commentBuffer == null) {
+            sqlBuffer.append(",\"").append(comment).append("\"),");
+        } else {
+            sqlBuffer.append(",\"").append(commentBuffer).append("\"),");
+        }
+
+        addressRandom.rowFinished();
+        nationKeyRandom.rowFinished();
+        phoneRandom.rowFinished();
+        accountBalanceRandom.rowFinished();
+        commentRandom.rowFinished();
+        bbbCommentRandom.rowFinished();
+        bbbJunkRandom.rowFinished();
+        bbbOffsetRandom.rowFinished();
+        bbbTypeRandom.rowFinished();
+
+        index++;
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/generator/TableRowGenerator.java
+++ b/batch-tool/src/main/java/worker/tpch/generator/TableRowGenerator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.generator;
+
+import io.airlift.tpch.Distributions;
+import io.airlift.tpch.TextPool;
+
+public abstract class TableRowGenerator {
+
+    protected final Distributions distributions;
+    protected final TextPool textPool;
+    protected final long startIndex;
+    protected final long rowCount;
+
+    protected long index = 0;
+
+    public TableRowGenerator(Distributions distributions, TextPool textPool,
+                             long startIndex, long rowCount) {
+        this.distributions = distributions;
+        this.textPool = textPool;
+        this.startIndex = startIndex;
+        this.rowCount = rowCount;
+    }
+
+    public boolean hasNext() {
+        return index < rowCount;
+    }
+
+    /**
+     * 以 sql values 的形式 append 一行
+     * 尽可能不生成 String 中间对象
+     */
+    public abstract void appendNextRow(StringBuilder sqlBuffer);
+
+}

--- a/batch-tool/src/main/java/worker/tpch/util/RandomAlphaNumeric.java
+++ b/batch-tool/src/main/java/worker/tpch/util/RandomAlphaNumeric.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.util;
+
+import io.airlift.tpch.AbstractRandomInt;
+
+public class RandomAlphaNumeric
+    extends AbstractRandomInt {
+    private static final char[] ALPHA_NUMERIC =
+        "0123456789abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ,".toCharArray();
+
+    private static final double LOW_LENGTH_MULTIPLIER = 0.4;
+    private static final double HIGH_LENGTH_MULTIPLIER = 1.6;
+
+    private static final int USAGE_PER_ROW = 9;
+
+    private final int minLength;
+    private final int maxLength;
+
+    public RandomAlphaNumeric(long seed, int averageLength) {
+        this(seed, averageLength, 1);
+    }
+
+    public RandomAlphaNumeric(long seed, int averageLength, int expectedRowCount) {
+        super(seed, USAGE_PER_ROW * expectedRowCount);
+        this.minLength = (int) (averageLength * LOW_LENGTH_MULTIPLIER);
+        this.maxLength = (int) (averageLength * HIGH_LENGTH_MULTIPLIER);
+    }
+
+    public void appendNextValue(StringBuilder stringBuilder) {
+        int len = nextInt(minLength, maxLength);
+
+        long charIndex = 0;
+        for (int i = 0; i < len; i++) {
+            if (i % 5 == 0) {
+                charIndex = nextInt(0, Integer.MAX_VALUE);
+            }
+            stringBuilder.append(ALPHA_NUMERIC[(int) (charIndex & 0x3f)]);
+            charIndex >>= 6;
+        }
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/util/RandomPhoneNumber.java
+++ b/batch-tool/src/main/java/worker/tpch/util/RandomPhoneNumber.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.util;
+
+import io.airlift.tpch.AbstractRandomInt;
+
+public class RandomPhoneNumber
+    extends AbstractRandomInt {
+    // limited by country codes in phone numbers
+    private static final int NATIONS_MAX = 90;
+
+    public RandomPhoneNumber(long seed) {
+        this(seed, 1);
+    }
+
+    public RandomPhoneNumber(long seed, int expectedRowCount) {
+        super(seed, 3 * expectedRowCount);
+    }
+
+    public void appendNextValue(StringBuilder stringBuilder, long nationKey) {
+        stringBuilder.append((10 + (nationKey % NATIONS_MAX)))
+            .append('-').append(nextInt(100, 999))
+            .append('-').append(nextInt(100, 999))
+            .append('-').append(nextInt(1000, 9999));
+    }
+}

--- a/batch-tool/src/main/java/worker/tpch/util/StringBufferUtil.java
+++ b/batch-tool/src/main/java/worker/tpch/util/StringBufferUtil.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright [2013-2021], Alibaba Group Holding Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package worker.tpch.util;
+
+public class StringBufferUtil {
+
+    private static final int DAYS_PER_CYCLE = 146097;
+    private static final long DAYS_0000_TO_1970 = (DAYS_PER_CYCLE * 5L) - (30L * 365L + 7L);
+
+    /**
+     * 转为两位小数的字符串表示
+     * 并append
+     */
+    public static void appendDecimalWithFrac2(StringBuilder sqlBuffer, long l) {
+        long intPart = l / 100;
+        long fracPart = l % 100;
+        sqlBuffer.append(intPart).append('.').append(fracPart);
+    }
+
+    /**
+     * Customer#%09d
+     */
+    public static void appendCustomerName(StringBuilder sqlBuffer, long key) {
+        sqlBuffer.append("Customer#");
+        append9Digits(sqlBuffer, key);
+    }
+
+    /**
+     * Customer#%09d
+     */
+    public static void appendClerk(StringBuilder sqlBuffer, long key) {
+        sqlBuffer.append("Clerk#");
+        append9Digits(sqlBuffer, key);
+    }
+
+    /**
+     * Supplier#%09d
+     */
+    public static void appendSupplier(StringBuilder sqlBuffer, long key) {
+        sqlBuffer.append("Supplier#");
+        append9Digits(sqlBuffer, key);
+    }
+
+    private static void append9Digits(StringBuilder sqlBuffer, long key) {
+        if (key >= 100_00) {
+            if (key >= 100_000_000) {
+                sqlBuffer.append(key);
+            } else if (key >= 100_000_00) {
+                sqlBuffer.append('0').append(key);
+            } else if (key >= 100_000_0) {
+                sqlBuffer.append("00").append(key);
+            } else if (key >= 100_000) {
+                sqlBuffer.append("000").append(key);
+            } else {
+                sqlBuffer.append("0000").append(key);
+            }
+        } else {
+            if (key >= 100_0) {
+                sqlBuffer.append("00000").append(key);
+            } else if (key >= 100) {
+                sqlBuffer.append("000000").append(key);
+            } else if (key >= 10) {
+                sqlBuffer.append("0000000").append(key);
+            } else if (key >= 0) {
+                sqlBuffer.append("00000000").append(key);
+            }
+        }
+    }
+
+    /**
+     * 格式 yyyy-MM-dd
+     *
+     * @param days 自从1970-01-01经过的天数
+     */
+    public static void formatDateByDays(StringBuilder sqlBuffer, int days) {
+        long zeroDay = days + DAYS_0000_TO_1970 - 60;
+        long adjust = 0;
+        if (zeroDay < 0) {
+            long adjustCycles = (zeroDay + 1) / DAYS_PER_CYCLE - 1;
+            adjust = adjustCycles * 400;
+            zeroDay += -adjustCycles * DAYS_PER_CYCLE;
+        }
+        long yearEst = (400 * zeroDay + 591) / DAYS_PER_CYCLE;
+        long doyEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400);
+        if (doyEst < 0) {
+            yearEst--;
+            doyEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400);
+        }
+        yearEst += adjust;
+        int marchDoy0 = (int) doyEst;
+
+        // convert march-based values back to january-based
+        int marchMonth0 = (marchDoy0 * 5 + 2) / 153;
+        int month = (marchMonth0 + 2) % 12 + 1;
+        int dom = marchDoy0 - (marchMonth0 * 306 + 5) / 10 + 1;
+        yearEst += marchMonth0 / 10;
+
+        // skip valid check
+        int year = (int) yearEst;
+
+        sqlBuffer.append(year).append('-');
+        if (month < 10) {
+            sqlBuffer.append('0');
+        }
+        sqlBuffer.append(month).append('-');
+        if (dom < 10) {
+            sqlBuffer.append('0');
+        }
+        sqlBuffer.append(dom);
+    }
+}


### PR DESCRIPTION
1. 支持在线导入TPC-H数据集，无需生成文本数据，参数：`-benchmark tpch -scale ${规格}`；可以使用`-t` 导入指定的表，比如 `-benchmark tpch -scale 100 -t "lineitem;orders"` 就只会导入100G 数据集的 lineitem表和 orders表
2. 优化部分debug日志